### PR TITLE
Faster iteration

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -34,3 +34,6 @@ jobs:
 
     - name: Build
       run: xcodebuild clean test -scheme '${{ matrix.run-config['scheme'] }}' -destination '${{ matrix.run-config['destination'] }}' -showBuildTimingSummary
+
+    - name: DocBuild
+      run: xcodebuild docbuild -scheme '${{ matrix.run-config['scheme'] }}' -destination '${{ matrix.run-config['destination'] }}' -derivedDataPath /tmp/docbuild

--- a/Sources/Lindenmayer/BuiltinModules.swift
+++ b/Sources/Lindenmayer/BuiltinModules.swift
@@ -19,32 +19,36 @@ public extension Modules {
         public var render2D: [TwoDRenderCmd] = [RenderCommand.Draw(length: 10)] // draws a line 10 units long
         public init() {}
     }
-    
+
     // MARK: - Built-in Modules that are effectively wrappers around specific rendering commands
-    
+
     struct TurnLeft: Module {
         public let name = RenderCommand.turnLeft.name
         public let angle: Double
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.TurnLeft(angle: angle)]
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.TurnLeft(angle: angle)
         }
+
         public init(angle: Double = 90) {
             self.angle = angle
         }
     }
-    
+
     struct TurnRight: Module {
         public let name = RenderCommand.turnRight.name
         public let angle: Double
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.TurnRight(angle: angle)]
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.TurnRight(angle: angle)
         }
+
         public init(angle: Double = 90) {
             self.angle = angle
         }
@@ -56,9 +60,11 @@ public extension Modules {
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.Draw(length: length)]
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.Draw(length: length)
         }
+
         public init(length: Double = 1) {
             self.length = length
         }
@@ -70,9 +76,11 @@ public extension Modules {
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.Move(length: length)]
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.Move(length: length)
         }
+
         public init(length: Double = 1) {
             self.length = length
         }
@@ -83,21 +91,25 @@ public extension Modules {
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.Branch()]
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.Branch()
         }
+
         public init() {}
     }
 
     struct EndBranch: Module {
         public let name = RenderCommand.endBranch.name
-        
+
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.EndBranch()]
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.EndBranch()
         }
+
         public init() {}
     }
 
@@ -107,23 +119,27 @@ public extension Modules {
         public var render2D: [TwoDRenderCmd] {
             []
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.RollLeft(angle: angle)
         }
+
         public init(angle: Double = 90) {
             self.angle = angle
         }
     }
-    
+
     struct RollRight: Module {
         public let name = RenderCommand.rollRight.name
         public let angle: Double
         public var render2D: [TwoDRenderCmd] {
             []
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.RollRight(angle: angle)
         }
+
         public init(angle: Double = 90) {
             self.angle = angle
         }
@@ -135,20 +151,23 @@ public extension Modules {
         public var render2D: [TwoDRenderCmd] {
             []
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.PitchUp(angle: angle)
         }
+
         public init(angle: Double = 90) {
             self.angle = angle
         }
     }
-    
+
     struct PitchDown: Module {
         public let name = RenderCommand.pitchDown.name
         public let angle: Double
         public var render2D: [TwoDRenderCmd] {
             []
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.PitchDown(angle: angle)
         }
@@ -159,10 +178,11 @@ public extension Modules {
         public var render2D: [TwoDRenderCmd] {
             []
         }
+
         public var render3D: ThreeDRenderCmd {
             RenderCommand.SpinToFlat()
         }
+
         public init() {}
     }
-
 }

--- a/Sources/Lindenmayer/Examples2D.swift
+++ b/Sources/Lindenmayer/Examples2D.swift
@@ -66,7 +66,7 @@ public enum Detailed2DExamples {
         public var render2D: [TwoDRenderCmd] = [
             RenderCommand.SetLineWidth(width: 3),
             RenderCommand.SetColor(representation: green),
-            RenderCommand.Draw(length: 5)
+            RenderCommand.Draw(length: 5),
         ]
     }
 

--- a/Sources/Lindenmayer/Examples2D.swift
+++ b/Sources/Lindenmayer/Examples2D.swift
@@ -36,7 +36,7 @@ public enum Examples2D: String, CaseIterable, Identifiable {
     }
 }
 
-enum Detailed2DExamples {
+public enum Detailed2DExamples {
     // - MARK: Algae example
 
     struct A: Module {

--- a/Sources/Lindenmayer/Examples2D.swift
+++ b/Sources/Lindenmayer/Examples2D.swift
@@ -34,17 +34,6 @@ public enum Examples2D: String, CaseIterable, Identifiable {
             return Detailed2DExamples.barnsleyFern
         }
     }
-
-    /// The L-system evolved by a number of iterations you provide.
-    /// - Parameter iterations: The number of times to evolve the L-system.
-    /// - Returns: The updated L-system from the number of evolutions you provided.
-    public func evolved(iterations: Int) -> LSystem {
-        var evolved: LSystem = lsystem
-        do {
-            evolved = try evolved.evolve(iterations: iterations)
-        } catch {}
-        return evolved
-    }
 }
 
 enum Detailed2DExamples {

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -61,7 +61,7 @@ public enum Detailed3DExamples {
 
     /*
      Monopodial tree - as described by Honda
-     
+
      #define r1   0.9   /* Contraction ratio for the trunk */
      #define r2   0.6   /* Contraction ratio for branches */
      #define a0   45    /* Branching angle from the trunk */
@@ -203,7 +203,7 @@ public enum Detailed3DExamples {
         parameters: defines
     )
     .rewriteWithParams(directContext: Trunk.self) { trunk, params in
-        
+
         // original: !(w) F(s) [ &(a0) B(s * r2, w * wr) ] /(d) A(s * r1, w * wr)
         // Conversion:
         // s -> trunk.growthDistance, w -> trunk.diameter

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -113,16 +113,23 @@ public enum Detailed3DExamples {
 
     struct Trunk: Module {
         public var name = "A"
-        public var render3D: ThreeDRenderCmd {
-            RenderCommand.Cylinder(
-                length: growthDistance,
-                radius: diameter / 2,
-                color: ColorRepresentation(red: 0.7, green: 0.7, blue: 0.1, alpha: 0.9)
-            )
-        }
 
         let growthDistance: Double // start at 1
         let diameter: Double // start at 10
+    }
+
+    struct MainBranch: Module {
+        public var name = "B"
+
+        let growthDistance: Double
+        let diameter: Double
+    }
+
+    struct SecondaryBranch: Module {
+        public var name = "C"
+
+        let growthDistance: Double
+        let diameter: Double
     }
 
     struct StaticTrunk: Module {
@@ -132,34 +139,6 @@ public enum Detailed3DExamples {
                 length: growthDistance,
                 radius: diameter / 2,
                 color: ColorRepresentation(red: 0.7, green: 0.3, blue: 0.1, alpha: 0.95)
-            )
-        }
-
-        let growthDistance: Double
-        let diameter: Double
-    }
-
-    struct MainBranch: Module {
-        public var name = "B"
-        public var render3D: ThreeDRenderCmd {
-            RenderCommand.Cylinder(
-                length: growthDistance,
-                radius: diameter / 2,
-                color: ColorRepresentation(red: 0.3, green: 0.9, blue: 0.1, alpha: 0.9)
-            )
-        }
-
-        let growthDistance: Double
-        let diameter: Double
-    }
-
-    struct SecondaryBranch: Module {
-        public var name = "C"
-        public var render3D: ThreeDRenderCmd {
-            RenderCommand.Cylinder(
-                length: growthDistance,
-                radius: diameter / 2,
-                color: ColorRepresentation(red: 0.3, green: 0.1, blue: 0.9, alpha: 0.9)
             )
         }
 

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -1,6 +1,6 @@
 //
 //  Examples3D.swift
-//  
+//
 //
 //  Created by Joseph Heck on 1/3/22.
 //
@@ -29,7 +29,6 @@ public enum Examples3D: String, CaseIterable, Identifiable {
 }
 
 public enum Detailed3DExamples {
-    
     // - MARK: 3D Algae test
 
     struct Cyl: Module {
@@ -170,7 +169,7 @@ public enum Detailed3DExamples {
             RenderCommand.Cylinder(
                 length: growthDistance,
                 radius: diameter / 2,
-                color:ColorRepresentation(red: 0.3, green: 0.1, blue: 0.9, alpha: 0.9)
+                color: ColorRepresentation(red: 0.3, green: 0.1, blue: 0.9, alpha: 0.9)
             )
         }
 
@@ -187,11 +186,12 @@ public enum Detailed3DExamples {
         var widthContraction: Double = 0.707 /* Width contraction ratio */
         var trunklength: Double = 10.0
         var trunkdiameter: Double = 2.0
-        
+
         init(r1: Double = 0.9,
-                 r2: Double = 0.6,
-                 a0: Double = 45,
-                 a2: Double = 45) {
+             r2: Double = 0.6,
+             a0: Double = 45,
+             a2: Double = 45)
+        {
             contractionRatioForTrunk = r1
             contractionRatioForBranch = r2
             branchAngle = a0
@@ -268,7 +268,7 @@ public enum Detailed3DExamples {
 
             Modules.EndBranch(),
             MainBranch(growthDistance: branch.growthDistance * params.contractionRatioForBranch,
-                                    diameter: branch.diameter * params.widthContraction)
+                       diameter: branch.diameter * params.widthContraction),
         ]
     }
 
@@ -284,7 +284,6 @@ public enum Detailed3DExamples {
 //    p1 : A(l,w) : * → !(w)F(l)[&(a1)B(l*r1,w*wr)] /(180)[&(a2 )B(l*r2 ,w*wr )]
 //    p2 : B(l,w) : * → !(w)F(l)[+(a1)$B(l*r1,w*wr)] [-(a2 )$B(l*r2 ,w*wr )]
 
-    
     // - MARK: Random Bush
 
     struct Stem2: Module {
@@ -321,13 +320,13 @@ public enum Detailed3DExamples {
                 return [
                     StaticStem2(length: 2),
                     Modules.PitchDown(angle: Double(rng.randomFloat(in: lower ... upper))),
-                    Stem2(length: stem.length)
+                    Stem2(length: stem.length),
                 ]
             } else {
                 return [
                     StaticStem2(length: 2),
                     Modules.PitchUp(angle: Double(rng.randomFloat(in: lower ... upper))),
-                    Stem2(length: stem.length)
+                    Stem2(length: stem.length),
                 ]
             }
         }

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -177,7 +177,7 @@ public enum Detailed3DExamples {
         let diameter: Double
     }
 
-    public class Definitions {
+    public struct Definitions: Equatable {
         var contractionRatioForTrunk: Double = 0.9 /* Contraction ratio for the trunk */
         var contractionRatioForBranch: Double = 0.6 /* Contraction ratio for branches */
         var branchAngle: Double = 45 /* Branching angle from the trunk */

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -28,7 +28,7 @@ public enum Examples3D: String, CaseIterable, Identifiable {
     }
 }
 
-enum Detailed3DExamples {
+public enum Detailed3DExamples {
     
     // - MARK: 3D Algae test
 
@@ -50,7 +50,7 @@ enum Detailed3DExamples {
         )
     }
 
-    static var algae3D = Lindenmayer.basic(Cyl())
+    public static var algae3D = Lindenmayer.basic(Cyl())
         .rewrite(Cyl.self) { _ in
             [Cyl(), S()]
         }
@@ -178,7 +178,7 @@ enum Detailed3DExamples {
         let diameter: Double
     }
 
-    struct Definitions {
+    public class Definitions {
         var contractionRatioForTrunk: Double = 0.9 /* Contraction ratio for the trunk */
         var contractionRatioForBranch: Double = 0.6 /* Contraction ratio for branches */
         var branchAngle: Double = 45 /* Branching angle from the trunk */
@@ -200,17 +200,17 @@ enum Detailed3DExamples {
     }
 
     static let defines = Definitions()
-    static let figure2_6A = defines
-    static let figure2_6B = Definitions(r1: 0.9, r2: 0.9, a0: 45, a2: 45)
-    static let figure2_6C = Definitions(r1: 0.9, r2: 0.8, a0: 45, a2: 45)
-    static let figure2_6D = Definitions(r1: 0.9, r2: 0.7, a0: 30, a2: -30)
+    public static let figure2_6A = defines
+    public static let figure2_6B = Definitions(r1: 0.9, r2: 0.9, a0: 45, a2: 45)
+    public static let figure2_6C = Definitions(r1: 0.9, r2: 0.8, a0: 45, a2: 45)
+    public static let figure2_6D = Definitions(r1: 0.9, r2: 0.7, a0: 30, a2: -30)
 
-    static let figure2_7A = Definitions(r1: 0.9, r2: 0.7, a0: 5, a2: 65)
-    static let figure2_7B = Definitions(r1: 0.9, r2: 0.7, a0: 10, a2: 60)
-    static let figure2_7C = Definitions(r1: 0.9, r2: 0.8, a0: 20, a2: 50)
-    static let figure2_7D = Definitions(r1: 0.9, r2: 0.8, a0: 35, a2: 35)
+    public static let figure2_7A = Definitions(r1: 0.9, r2: 0.7, a0: 5, a2: 65)
+    public static let figure2_7B = Definitions(r1: 0.9, r2: 0.7, a0: 10, a2: 60)
+    public static let figure2_7C = Definitions(r1: 0.9, r2: 0.8, a0: 20, a2: 50)
+    public static let figure2_7D = Definitions(r1: 0.9, r2: 0.8, a0: 35, a2: 35)
 
-    static var hondaTree = Lindenmayer.withDefines(
+    public static var hondaTree = Lindenmayer.withDefines(
         [Trunk(growthDistance: defines.trunklength, diameter: defines.trunkdiameter)],
         prng: PRNG(seed: 42),
         parameters: defines
@@ -283,13 +283,7 @@ enum Detailed3DExamples {
 //    ω : A(1,10)
 //    p1 : A(l,w) : * → !(w)F(l)[&(a1)B(l*r1,w*wr)] /(180)[&(a2 )B(l*r2 ,w*wr )]
 //    p2 : B(l,w) : * → !(w)F(l)[+(a1)$B(l*r1,w*wr)] [-(a2 )$B(l*r2 ,w*wr )]
-    
-    
-    
-    
-    
-    
-    
+
     
     // - MARK: Random Bush
 
@@ -317,9 +311,7 @@ enum Detailed3DExamples {
         }
     }
 
-    struct BushDefinitions {}
-
-    static var randomBush = Lindenmayer.withRNG(Stem2(length: 1), prng: PRNG(seed: 42))
+    public static var randomBush = Lindenmayer.withRNG(Stem2(length: 1), prng: PRNG(seed: 42))
         .rewriteWithRNG(directContext: Stem2.self) { stem, rng -> [Module] in
 
             let upper: Float = 45.0

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -26,17 +26,6 @@ public enum Examples3D: String, CaseIterable, Identifiable {
             return Detailed3DExamples.randomBush
         }
     }
-
-    /// The L-system evolved by a number of iterations you provide.
-    /// - Parameter iterations: The number of times to evolve the L-system.
-    /// - Returns: The updated L-system from the number of evolutions you provided.
-    public func evolved(iterations: Int) -> LSystem {
-        var evolved: LSystem = lsystem
-        do {
-            evolved = try evolved.evolve(iterations: iterations)
-        } catch {}
-        return evolved
-    }
 }
 
 enum Detailed3DExamples {
@@ -190,17 +179,36 @@ enum Detailed3DExamples {
     }
 
     struct Definitions {
-        let contractionRatioForTrunk: Double = 0.9 /* Contraction ratio for the trunk */
-        let contractionRatioForBranch: Double = 0.6 /* Contraction ratio for branches */
-        let branchAngle: Double = 45 /* Branching angle from the trunk */
-        let lateralBranchAngle: Double = 45 /* Branching angle for lateral axes */
-        let divergence: Double = 137.5 /* Divergence angle */
-        let widthContraction: Double = 0.707 /* Width contraction ratio */
-        let trunklength: Double = 10.0
-        let trunkdiameter: Double = 2.0
+        var contractionRatioForTrunk: Double = 0.9 /* Contraction ratio for the trunk */
+        var contractionRatioForBranch: Double = 0.6 /* Contraction ratio for branches */
+        var branchAngle: Double = 45 /* Branching angle from the trunk */
+        var lateralBranchAngle: Double = 45 /* Branching angle for lateral axes */
+        var divergence: Double = 137.5 /* Divergence angle */
+        var widthContraction: Double = 0.707 /* Width contraction ratio */
+        var trunklength: Double = 10.0
+        var trunkdiameter: Double = 2.0
+        
+        init(r1: Double = 0.9,
+                 r2: Double = 0.6,
+                 a0: Double = 45,
+                 a2: Double = 45) {
+            contractionRatioForTrunk = r1
+            contractionRatioForBranch = r2
+            branchAngle = a0
+            lateralBranchAngle = a2
+        }
     }
 
     static let defines = Definitions()
+    static let figure2_6A = defines
+    static let figure2_6B = Definitions(r1: 0.9, r2: 0.9, a0: 45, a2: 45)
+    static let figure2_6C = Definitions(r1: 0.9, r2: 0.8, a0: 45, a2: 45)
+    static let figure2_6D = Definitions(r1: 0.9, r2: 0.7, a0: 30, a2: -30)
+
+    static let figure2_7A = Definitions(r1: 0.9, r2: 0.7, a0: 5, a2: 65)
+    static let figure2_7B = Definitions(r1: 0.9, r2: 0.7, a0: 10, a2: 60)
+    static let figure2_7C = Definitions(r1: 0.9, r2: 0.8, a0: 20, a2: 50)
+    static let figure2_7D = Definitions(r1: 0.9, r2: 0.8, a0: 35, a2: 35)
 
     static var hondaTree = Lindenmayer.withDefines(
         [Trunk(growthDistance: defines.trunklength, diameter: defines.trunkdiameter)],
@@ -264,6 +272,25 @@ enum Detailed3DExamples {
         ]
     }
 
+    // Sympodial tree - as described by Aono and Kunii
+    // ABOP - page 58, 59
+//    n = 10
+//    #define r1 0.9 /* contraction ratio 1 */
+//    #define r2 0.7 /* contraction ratio 2 */
+//    #define a1 10 /* branching angle 1 */
+//    #define a2 60 /* branching angle 2 */
+//    #define wr 0.707 /* width decrease rate */
+//    ω : A(1,10)
+//    p1 : A(l,w) : * → !(w)F(l)[&(a1)B(l*r1,w*wr)] /(180)[&(a2 )B(l*r2 ,w*wr )]
+//    p2 : B(l,w) : * → !(w)F(l)[+(a1)$B(l*r1,w*wr)] [-(a2 )$B(l*r2 ,w*wr )]
+    
+    
+    
+    
+    
+    
+    
+    
     // - MARK: Random Bush
 
     struct Stem2: Module {

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -238,7 +238,7 @@ public enum Detailed3DExamples {
     }
 
     // - MARK: Sympodial Trees
-    
+
     // Sympodial tree - as described by Aono and Kunii
     // ABOP - page 58, 59
     //    n = 10
@@ -269,7 +269,7 @@ public enum Detailed3DExamples {
             self.a2 = a2
         }
     }
-    
+
     public static let figure2_7A = SympodialDefn(r1: 0.9, r2: 0.7, a1: 5, a2: 65)
     public static let figure2_7B = SympodialDefn(r1: 0.9, r2: 0.7, a1: 10, a2: 60)
     public static let figure2_7C = SympodialDefn(r1: 0.9, r2: 0.8, a1: 20, a2: 50)
@@ -281,7 +281,7 @@ public enum Detailed3DExamples {
         parameters: figure2_7A
     ).rewriteWithParams(directContext: MainBranch.self) { node, params in
         //    p1 : A(l,w) : * → !(w)F(l)[&(a1)B(l*r1,w*wr)] /(180)[&(a2 )B(l*r2 ,w*wr )]
-        return [
+        [
             StaticTrunk(growthDistance: node.growthDistance, diameter: node.diameter),
             Modules.Branch(),
             Modules.PitchDown(angle: params.a1),
@@ -296,7 +296,7 @@ public enum Detailed3DExamples {
     }
     .rewriteWithParams(directContext: SecondaryBranch.self) { node, params in
         //    p2 : B(l,w) : * → !(w)F(l)[+(a1)$B(l*r1,w*wr)] [-(a2 )$B(l*r2 ,w*wr )]
-        return [
+        [
             StaticTrunk(growthDistance: node.growthDistance, diameter: node.diameter),
             Modules.Branch(),
             Modules.RollRight(angle: params.a1),

--- a/Sources/Lindenmayer/GraphicsContextRenderer.swift
+++ b/Sources/Lindenmayer/GraphicsContextRenderer.swift
@@ -40,7 +40,7 @@ public struct GraphicsContextRenderer {
         case left
         case right
     }
-    
+
     public init(unitLength: Double = 1) {
         self.unitLength = unitLength
     }
@@ -162,7 +162,6 @@ public struct GraphicsContextRenderer {
                 // print("current location: [\(currentState.position.x), \(currentState.position.y)]")
                 // print("Minimums: [\(minX), \(minY)]")
                 // print("Maximums: [\(maxX), \(maxY)]")
-
             }
         }
         return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)

--- a/Sources/Lindenmayer/LSystem.swift
+++ b/Sources/Lindenmayer/LSystem.swift
@@ -24,8 +24,8 @@ public protocol LSystem {
 
     /// Returns a new L-system after processing the current state against the rules to generate a new state sequence.
     func evolve() -> Self
-    
-    /// Returns a new L-system reset to its original state. 
+
+    /// Returns a new L-system reset to its original state.
     func reset() -> Self
 
     /// Returns a set of modules around the index location you provide.

--- a/Sources/Lindenmayer/LSystem.swift
+++ b/Sources/Lindenmayer/LSystem.swift
@@ -17,11 +17,13 @@ public protocol LSystem {
     /// The sequence of rules that the L-system uses to process and evolve its state.
     var rules: [Rule] { get }
 
-    /// Returns a new L-system that is evolved by the number of iterations you provide.
-    func evolve(iterations: Int) throws -> LSystem
+    /// The L-system evolved by a number of iterations you provide.
+    /// - Parameter iterations: The number of times to evolve the L-system.
+    /// - Returns: The updated L-system from the number of evolutions you provided.
+    func evolved(iterations: Int) -> LSystem
 
     /// Returns a new L-system after processing the current state against the rules to generate a new state sequence.
-    func evolve() throws -> LSystem
+    func evolve() -> LSystem
 
     /// Returns a set of modules around the index location you provide.
     /// - Parameter atIndex: The index location of the state of the current L-system.
@@ -63,7 +65,7 @@ public extension LSystem {
     /// When applying the rule, the element that matched is replaced with what the rule returns from ``Rule/produce(_:)``.
     /// The types of errors that may be thrown is defined by any errors referenced and thrown within the set of rules you provide.
     /// - Returns: An updated Lindenmayer system.
-    func evolve() throws -> LSystem {
+    func evolve() -> LSystem {
         // Performance is O(n)(z) with the (n) number of atoms in the state and (z) number of rules to apply.
         // TODO(heckj): revisit this with async methods in mind, creating tasks for each iteration
         // in order to run the whole suite of the state in parallel for a new result. Await the whole
@@ -89,11 +91,13 @@ public extension LSystem {
         return updatedLSystem(with: newState)
     }
 
-    /// Updates the state of the Lindenmayer system by the number of iterations you provide.
-    func evolve(iterations: Int = 1) throws -> LSystem {
+    /// The L-system evolved by a number of iterations you provide.
+    /// - Parameter iterations: The number of times to evolve the L-system.
+    /// - Returns: The updated L-system from the number of evolutions you provided.
+    func evolved(iterations: Int = 1) -> LSystem {
         var lsys: LSystem = self
         for _ in 0 ..< iterations {
-            lsys = try lsys.evolve()
+            lsys = lsys.evolve()
         }
         return lsys
     }

--- a/Sources/Lindenmayer/LSystem.swift
+++ b/Sources/Lindenmayer/LSystem.swift
@@ -24,6 +24,9 @@ public protocol LSystem {
 
     /// Returns a new L-system after processing the current state against the rules to generate a new state sequence.
     func evolve() -> LSystem
+    
+    /// Returns a new L-system reset to its original state. 
+    func reset() -> LSystem
 
     /// Returns a set of modules around the index location you provide.
     /// - Parameter atIndex: The index location of the state of the current L-system.

--- a/Sources/Lindenmayer/LSystem.swift
+++ b/Sources/Lindenmayer/LSystem.swift
@@ -20,13 +20,13 @@ public protocol LSystem {
     /// The L-system evolved by a number of iterations you provide.
     /// - Parameter iterations: The number of times to evolve the L-system.
     /// - Returns: The updated L-system from the number of evolutions you provided.
-    func evolved(iterations: Int) -> LSystem
+    func evolved(iterations: Int) -> Self
 
     /// Returns a new L-system after processing the current state against the rules to generate a new state sequence.
-    func evolve() -> LSystem
+    func evolve() -> Self
     
     /// Returns a new L-system reset to its original state. 
-    func reset() -> LSystem
+    func reset() -> Self
 
     /// Returns a set of modules around the index location you provide.
     /// - Parameter atIndex: The index location of the state of the current L-system.
@@ -35,7 +35,7 @@ public protocol LSystem {
     func modules(atIndex: Int) -> ModuleSet
 
     /// Returns a new L-system with the provided state.
-    func updatedLSystem(with state: [Module]) -> LSystem
+    func updatedLSystem(with state: [Module]) -> Self
 }
 
 public extension LSystem {
@@ -68,7 +68,7 @@ public extension LSystem {
     /// When applying the rule, the element that matched is replaced with what the rule returns from ``Rule/produce(_:)``.
     /// The types of errors that may be thrown is defined by any errors referenced and thrown within the set of rules you provide.
     /// - Returns: An updated Lindenmayer system.
-    func evolve() -> LSystem {
+    func evolve() -> Self {
         // Performance is O(n)(z) with the (n) number of atoms in the state and (z) number of rules to apply.
         // TODO(heckj): revisit this with async methods in mind, creating tasks for each iteration
         // in order to run the whole suite of the state in parallel for a new result. Await the whole
@@ -97,8 +97,8 @@ public extension LSystem {
     /// The L-system evolved by a number of iterations you provide.
     /// - Parameter iterations: The number of times to evolve the L-system.
     /// - Returns: The updated L-system from the number of evolutions you provided.
-    func evolved(iterations: Int = 1) -> LSystem {
-        var lsys: LSystem = self
+    func evolved(iterations: Int = 1) -> Self {
+        var lsys: Self = self
         for _ in 0 ..< iterations {
             lsys = lsys.evolve()
         }

--- a/Sources/Lindenmayer/LSystemBasic.swift
+++ b/Sources/Lindenmayer/LSystemBasic.swift
@@ -38,11 +38,11 @@ public struct LSystemBasic: LSystem {
     /// Returns a new L-system with the provided state.
     /// - Parameter state: The sequence of modules that represent the new state.
     /// - Returns: A new L-system with the updated state that has the same rules.
-    public func updatedLSystem(with state: [Module]) -> LSystem {
+    public func updatedLSystem(with state: [Module]) -> Self {
         return LSystemBasic(self.axiom, state: state, rules: rules)
     }
     
-    public func reset() -> LSystem {
+    public func reset() -> Self {
         return LSystemBasic(self.axiom, state: nil, rules: rules)
     }
 }

--- a/Sources/Lindenmayer/LSystemBasic.swift
+++ b/Sources/Lindenmayer/LSystemBasic.swift
@@ -39,11 +39,11 @@ public struct LSystemBasic: LSystem {
     /// - Parameter state: The sequence of modules that represent the new state.
     /// - Returns: A new L-system with the updated state that has the same rules.
     public func updatedLSystem(with state: [Module]) -> Self {
-        return LSystemBasic(self.axiom, state: state, rules: rules)
+        return LSystemBasic(axiom, state: state, rules: rules)
     }
-    
+
     public func reset() -> Self {
-        return LSystemBasic(self.axiom, state: nil, rules: rules)
+        return LSystemBasic(axiom, state: nil, rules: rules)
     }
 }
 

--- a/Sources/Lindenmayer/LSystemBasic.swift
+++ b/Sources/Lindenmayer/LSystemBasic.swift
@@ -11,6 +11,7 @@ import Foundation
 public struct LSystemBasic: LSystem {
     /// The sequence of modules that represents the current state of the L-system.
     public let state: [Module]
+    let axiom: [Module]
 
     /// The sequence of rules that the L-system uses to process and evolve its state.
     public var rules: [Rule]
@@ -22,9 +23,15 @@ public struct LSystemBasic: LSystem {
     ///   - prng: A psuedo-random number generator to use for stochastic rule productions.
     ///   - rules: A collection of rules that the Lindenmayer system applies when you call the evolve function.
     public init(_ axiom: [Module],
+                state: [Module]?,
                 rules: [Rule] = [])
     {
-        state = axiom
+        self.axiom = axiom
+        if let state = state {
+            self.state = state
+        } else {
+            state = axiom
+        }
         self.rules = rules
     }
 
@@ -32,7 +39,11 @@ public struct LSystemBasic: LSystem {
     /// - Parameter state: The sequence of modules that represent the new state.
     /// - Returns: A new L-system with the updated state that has the same rules.
     public func updatedLSystem(with state: [Module]) -> LSystem {
-        return LSystemBasic(state, rules: rules)
+        return LSystemBasic(self.axiom, state: state, rules: rules)
+    }
+    
+    public func reset() -> LSystem {
+        return LSystemBasic(self.axiom, rules: rules)
     }
 }
 

--- a/Sources/Lindenmayer/LSystemBasic.swift
+++ b/Sources/Lindenmayer/LSystemBasic.swift
@@ -30,7 +30,7 @@ public struct LSystemBasic: LSystem {
         if let state = state {
             self.state = state
         } else {
-            state = axiom
+            self.state = axiom
         }
         self.rules = rules
     }
@@ -43,7 +43,7 @@ public struct LSystemBasic: LSystem {
     }
     
     public func reset() -> LSystem {
-        return LSystemBasic(self.axiom, rules: rules)
+        return LSystemBasic(self.axiom, state: nil, rules: rules)
     }
 }
 
@@ -61,7 +61,7 @@ public extension LSystemBasic {
         let newRule = RewriteRuleDirect(direct: direct, where: evalClosure, produce: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -75,7 +75,7 @@ public extension LSystemBasic {
         let newRule = RewriteRuleDirect(direct: direct, where: nil, produce: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -91,7 +91,7 @@ public extension LSystemBasic {
         let newRule = RewriteRuleLeftDirect(leftType: leftContext, directType: directContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -105,7 +105,7 @@ public extension LSystemBasic {
         let newRule = RewriteRuleLeftDirect(leftType: leftContext, directType: directContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -121,7 +121,7 @@ public extension LSystemBasic {
         let newRule = RewriteRuleDirectRight(directType: directContext, rightType: rightContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -135,7 +135,7 @@ public extension LSystemBasic {
         let newRule = RewriteRuleDirectRight(directType: directContext, rightType: rightContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -151,7 +151,7 @@ public extension LSystemBasic {
         let newRule = RewriteRuleLeftDirectRight(leftType: leftContext, directType: directContext, rightType: rightContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -165,6 +165,6 @@ public extension LSystemBasic {
         let newRule = RewriteRuleLeftDirectRight(leftType: leftContext, directType: directContext, rightType: rightContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemBasic(state, rules: newRuleSet)
+        return LSystemBasic(axiom, state: state, rules: newRuleSet)
     }
 }

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -53,11 +53,11 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNu
     /// Returns a new L-system with the provided state.
     /// - Parameter state: The sequence of modules that represent the new state.
     /// - Returns: A new L-system with the updated state that has the same rules and parameters.
-    public func updatedLSystem(with state: [Module]) -> LSystem {
+    public func updatedLSystem(with state: [Module]) -> Self {
         return LSystemDefinesRNG<PType, PRNG>(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: rules)
     }
     
-    public func reset() -> LSystem {
+    public func reset() -> Self {
         self.prng.resetRNG(seed: self.prng.seed)
         return LSystemDefinesRNG<PType, PRNG>(axiom: self.axiom, state: nil, parameters: parameters, prng: prng, rules: rules)
     }

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -37,7 +37,7 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: RandomNumberGe
     {
         // Using [axiom] instead of [] ensures that we always have a state
         // environment that can be evolved based on the rules available.
-        axiom = axiom
+        self.axiom = axiom
         if let state = state {
             self.state = state
         } else {
@@ -52,11 +52,11 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: RandomNumberGe
     /// - Parameter state: The sequence of modules that represent the new state.
     /// - Returns: A new L-system with the updated state that has the same rules and parameters.
     public func updatedLSystem(with state: [Module]) -> LSystem {
-        return LSystemDefinesRNG<PType, PRNG>(axiom: state, parameters: parameters, prng: prng, rules: rules)
+        return LSystemDefinesRNG<PType, PRNG>(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: rules)
     }
     
     public func reset() -> LSystem {
-        return LSystemDefinesRNG<PType, PRNG>(self.axiom, state: state, parameters: parameters, rules: rules)
+        return LSystemDefinesRNG<PType, PRNG>(axiom: self.axiom, state: nil, parameters: parameters, prng: prng, rules: rules)
     }
 
 }
@@ -88,7 +88,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -113,7 +113,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -139,7 +139,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -163,7 +163,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -189,7 +189,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -213,7 +213,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -238,7 +238,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -261,7 +261,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 }
 
@@ -291,7 +291,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -315,7 +315,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
     
     /// Adds a rewriting rule to the L-System.
@@ -340,7 +340,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -363,7 +363,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
     
     /// Adds a rewriting rule to the L-System.
@@ -388,7 +388,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -411,7 +411,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
     
     
@@ -436,7 +436,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -458,7 +458,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 }
 
@@ -488,7 +488,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -512,7 +512,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -537,7 +537,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -560,7 +560,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -586,7 +586,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -609,7 +609,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -633,7 +633,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -655,7 +655,7 @@ public extension LSystemDefinesRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 }
 
@@ -673,7 +673,7 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleDirect(direct: direct, where: evalClosure, produce: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -687,7 +687,7 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleDirect(direct: direct, where: nil, produce: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -703,7 +703,7 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleLeftDirect(leftType: leftContext, directType: directContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -717,7 +717,7 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleLeftDirect(leftType: leftContext, directType: directContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -733,7 +733,7 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleDirectRight(directType: directContext, rightType: rightContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -747,7 +747,7 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleDirectRight(directType: directContext, rightType: rightContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -763,7 +763,7 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleLeftDirectRight(leftType: leftContext, directType: directContext, rightType: rightContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -777,6 +777,6 @@ public extension LSystemDefinesRNG {
         let newRule = RewriteRuleLeftDirectRight(leftType: leftContext, directType: directContext, rightType: rightContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemDefinesRNG(axiom: state, parameters: parameters, prng: prng, rules: newRuleSet)
+        return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
 }

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -12,7 +12,6 @@ import Squirrel3
 ///
 /// For more information on the background of Lindenmayer systems, see [Wikipedia's L-System](https://en.wikipedia.org/wiki/L-system).
 public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNumberGenerator, PType: AnyObject {
-    
     /// The sequence of rules that the L-system uses to process and evolve its state.
     public let rules: [Rule]
 
@@ -56,25 +55,25 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNu
     public func updatedLSystem(with state: [Module]) -> Self {
         return LSystemDefinesRNG<PType, PRNG>(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: rules)
     }
-    
+
     public func reset() -> Self {
-        self.prng.resetRNG(seed: self.prng.seed)
-        return LSystemDefinesRNG<PType, PRNG>(axiom: self.axiom, state: nil, parameters: parameters, prng: prng, rules: rules)
+        prng.resetRNG(seed: prng.seed)
+        return LSystemDefinesRNG<PType, PRNG>(axiom: axiom, state: nil, parameters: parameters, prng: prng, rules: rules)
     }
 
     public func setSeed(seed: UInt64) {
-        self.prng.resetRNG(seed: seed)
+        prng.resetRNG(seed: seed)
     }
 
     public mutating func setParameters(params: PType) {
-        self.parameters = params
+        parameters = params
     }
-    
+
     public mutating func set(seed: UInt64, params: PType) {
-        self.prng.resetRNG(seed: seed)
-        self.parameters = params
+        prng.resetRNG(seed: seed)
+        parameters = params
     }
-    
+
     /// Processes the current state against its rules to provide an updated L-system
     ///
     /// The Lindermayer system iterates through the rules provided, applying the first rule that matches the state from the rule to the current state of the system.
@@ -364,7 +363,7 @@ public extension LSystemDefinesRNG {
         newRuleSet.append(contentsOf: [rule])
         return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
-    
+
     /// Adds a rewriting rule to the L-System.
     /// - Parameters:
     ///   - left: An optional type of module that the rule matches to the left of the main module.
@@ -412,7 +411,7 @@ public extension LSystemDefinesRNG {
         newRuleSet.append(contentsOf: [rule])
         return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
-    
+
     /// Adds a rewriting rule to the L-System.
     /// - Parameters:
     ///   - left: An optional type of module that the rule matches to the left of the main module.
@@ -460,8 +459,7 @@ public extension LSystemDefinesRNG {
         newRuleSet.append(contentsOf: [rule])
         return LSystemDefinesRNG(axiom: axiom, state: state, parameters: parameters, prng: prng, rules: newRuleSet)
     }
-    
-    
+
     /// Adds a rewriting rule to the L-System.
     /// - Parameters:
     ///   - direct: The type of module that the rule matches

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -39,7 +39,7 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNu
     {
         // Using [axiom] instead of [] ensures that we always have a state
         // environment that can be evolved based on the rules available.
-        self.initialParameters = parameters.unwrap()
+        initialParameters = parameters.unwrap()
         self.axiom = axiom
         if let state = state {
             self.state = state
@@ -47,7 +47,7 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNu
             self.state = axiom
         }
         self.parameters = parameters
-        
+
         self.prng = prng
         self.rules = rules
     }

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -19,6 +19,7 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: RandomNumberGe
 
     /// The current state of the LSystem, expressed as a sequence of elements that conform to Module.
     public let state: [Module]
+    let axiom: [Module]
 
     var prng: RNGWrapper<PRNG>
 
@@ -29,13 +30,19 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: RandomNumberGe
     ///   - prng: A psuedo-random number generator to use for stochastic rule productions.
     ///   - rules: A collection of rules that the Lindenmayer system applies when you call the evolve function.
     public init(axiom: [Module],
+                state: [Module]?,
                 parameters: PType,
                 prng: RNGWrapper<PRNG>,
                 rules: [Rule] = [])
     {
         // Using [axiom] instead of [] ensures that we always have a state
         // environment that can be evolved based on the rules available.
-        state = axiom
+        axiom = axiom
+        if let state = state {
+            self.state = state
+        } else {
+            self.state = axiom
+        }
         self.parameters = parameters
         self.prng = prng
         self.rules = rules
@@ -47,6 +54,11 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: RandomNumberGe
     public func updatedLSystem(with state: [Module]) -> LSystem {
         return LSystemDefinesRNG<PType, PRNG>(axiom: state, parameters: parameters, prng: prng, rules: rules)
     }
+    
+    public func reset() -> LSystem {
+        return LSystemDefinesRNG<PType, PRNG>(self.axiom, state: state, parameters: parameters, rules: rules)
+    }
+
 }
 
 // - MARK: Rewrite rules including RNG and Parameters from the LSystem

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A parameterized, stochastic Lindenmayer system.
 ///
 /// For more information on the background of Lindenmayer systems, see [Wikipedia's L-System](https://en.wikipedia.org/wiki/L-system).
-public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: RandomNumberGenerator {
+public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNumberGenerator {
     /// The sequence of rules that the L-system uses to process and evolve its state.
     public let rules: [Rule]
 

--- a/Sources/Lindenmayer/LSystemRNG.swift
+++ b/Sources/Lindenmayer/LSystemRNG.swift
@@ -13,6 +13,7 @@ import Foundation
 public struct LSystemRNG<PRNG>: LSystem where PRNG: RandomNumberGenerator {
     /// The sequence of modules that represents the current state of the L-system.
     public let state: [Module]
+    let axiom: [Module]
 
     var prng: RNGWrapper<PRNG>
 
@@ -26,10 +27,16 @@ public struct LSystemRNG<PRNG>: LSystem where PRNG: RandomNumberGenerator {
     ///   - prng: A psuedo-random number generator to use for stochastic rule productions.
     ///   - rules: A collection of rules that the Lindenmayer system applies when you call the evolve function.
     public init(axiom: [Module],
+                state: [Module]?,
                 prng: RNGWrapper<PRNG>,
                 rules: [Rule] = [])
     {
-        state = axiom
+        axiom = axiom
+        if let state = state {
+            self.state = state
+        } else {
+            state = axiom
+        }
         self.prng = prng
         self.rules = rules
     }
@@ -38,8 +45,13 @@ public struct LSystemRNG<PRNG>: LSystem where PRNG: RandomNumberGenerator {
     /// - Parameter state: The sequence of modules that represent the new state.
     /// - Returns: A new L-system with the updated state that has the same rules.
     public func updatedLSystem(with state: [Module]) -> LSystem {
-        return LSystemRNG(axiom: state, prng: prng, rules: rules)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: rules)
     }
+    
+    public func reset() -> LSystem {
+        return LSystemRNG(self.axiom, prng: prng, rules: rules)
+    }
+
 }
 
 // - MARK: Rewrite rules including PRNG from the LSystem

--- a/Sources/Lindenmayer/LSystemRNG.swift
+++ b/Sources/Lindenmayer/LSystemRNG.swift
@@ -48,15 +48,15 @@ public struct LSystemRNG<PRNG>: LSystem where PRNG: SeededRandomNumberGenerator 
     public func updatedLSystem(with state: [Module]) -> Self {
         return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: rules)
     }
-    
+
     public func reset() -> Self {
-        self.prng.resetRNG(seed: self.prng.seed)
-        return LSystemRNG(axiom: self.axiom, state: nil, prng: prng, rules: rules)
+        prng.resetRNG(seed: prng.seed)
+        return LSystemRNG(axiom: axiom, state: nil, prng: prng, rules: rules)
     }
 
     public func evolve(with seed: UInt64) -> Self {
-        self.prng.resetRNG(seed: seed)
-        return self.evolve()
+        prng.resetRNG(seed: seed)
+        return evolve()
     }
 }
 

--- a/Sources/Lindenmayer/LSystemRNG.swift
+++ b/Sources/Lindenmayer/LSystemRNG.swift
@@ -45,16 +45,16 @@ public struct LSystemRNG<PRNG>: LSystem where PRNG: SeededRandomNumberGenerator 
     /// Returns a new L-system with the provided state.
     /// - Parameter state: The sequence of modules that represent the new state.
     /// - Returns: A new L-system with the updated state that has the same rules.
-    public func updatedLSystem(with state: [Module]) -> LSystem {
+    public func updatedLSystem(with state: [Module]) -> Self {
         return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: rules)
     }
     
-    public func reset() -> LSystem {
+    public func reset() -> Self {
         self.prng.resetRNG(seed: self.prng.seed)
         return LSystemRNG(axiom: self.axiom, state: nil, prng: prng, rules: rules)
     }
 
-    public func evolve(with seed: UInt64) -> LSystem {
+    public func evolve(with seed: UInt64) -> Self {
         self.prng.resetRNG(seed: seed)
         return self.evolve()
     }

--- a/Sources/Lindenmayer/LSystemRNG.swift
+++ b/Sources/Lindenmayer/LSystemRNG.swift
@@ -6,11 +6,12 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A stochastic Lindenmayer system.
 ///
 /// For more information on the background of Lindenmayer systems, see [Wikipedia's L-System](https://en.wikipedia.org/wiki/L-system).
-public struct LSystemRNG<PRNG>: LSystem where PRNG: RandomNumberGenerator {
+public struct LSystemRNG<PRNG>: LSystem where PRNG: SeededRandomNumberGenerator {
     /// The sequence of modules that represents the current state of the L-system.
     public let state: [Module]
     let axiom: [Module]

--- a/Sources/Lindenmayer/LSystemRNG.swift
+++ b/Sources/Lindenmayer/LSystemRNG.swift
@@ -50,9 +50,14 @@ public struct LSystemRNG<PRNG>: LSystem where PRNG: SeededRandomNumberGenerator 
     }
     
     public func reset() -> LSystem {
+        self.prng.resetRNG(seed: self.prng.seed)
         return LSystemRNG(axiom: self.axiom, state: nil, prng: prng, rules: rules)
     }
 
+    public func evolve(with seed: UInt64) -> LSystem {
+        self.prng.resetRNG(seed: seed)
+        return self.evolve()
+    }
 }
 
 // - MARK: Rewrite rules including PRNG from the LSystem

--- a/Sources/Lindenmayer/LSystemRNG.swift
+++ b/Sources/Lindenmayer/LSystemRNG.swift
@@ -31,11 +31,11 @@ public struct LSystemRNG<PRNG>: LSystem where PRNG: RandomNumberGenerator {
                 prng: RNGWrapper<PRNG>,
                 rules: [Rule] = [])
     {
-        axiom = axiom
+        self.axiom = axiom
         if let state = state {
             self.state = state
         } else {
-            state = axiom
+            self.state = axiom
         }
         self.prng = prng
         self.rules = rules
@@ -49,7 +49,7 @@ public struct LSystemRNG<PRNG>: LSystem where PRNG: RandomNumberGenerator {
     }
     
     public func reset() -> LSystem {
-        return LSystemRNG(self.axiom, prng: prng, rules: rules)
+        return LSystemRNG(axiom: self.axiom, state: nil, prng: prng, rules: rules)
     }
 
 }
@@ -80,7 +80,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -104,7 +104,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -129,7 +129,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -152,7 +152,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -178,7 +178,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -201,7 +201,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -225,7 +225,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -247,7 +247,7 @@ public extension LSystemRNG {
         )
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [rule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 }
 
@@ -267,7 +267,7 @@ public extension LSystemRNG {
         let newRule = RewriteRuleDirect(direct: direct, where: evalClosure, produce: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -281,7 +281,7 @@ public extension LSystemRNG {
         let newRule = RewriteRuleDirect(direct: direct, where: nil, produce: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -297,7 +297,7 @@ public extension LSystemRNG {
         let newRule = RewriteRuleLeftDirect(leftType: leftContext, directType: directContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -311,7 +311,7 @@ public extension LSystemRNG {
         let newRule = RewriteRuleLeftDirect(leftType: leftContext, directType: directContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -327,7 +327,7 @@ public extension LSystemRNG {
         let newRule = RewriteRuleDirectRight(directType: directContext, rightType: rightContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -341,7 +341,7 @@ public extension LSystemRNG {
         let newRule = RewriteRuleDirectRight(directType: directContext, rightType: rightContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -357,7 +357,7 @@ public extension LSystemRNG {
         let newRule = RewriteRuleLeftDirectRight(leftType: leftContext, directType: directContext, rightType: rightContext, where: evalClosure, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 
     /// Adds a rewriting rule to the L-System.
@@ -371,6 +371,6 @@ public extension LSystemRNG {
         let newRule = RewriteRuleLeftDirectRight(leftType: leftContext, directType: directContext, rightType: rightContext, where: nil, produces: produceClosure)
         var newRuleSet: [Rule] = rules
         newRuleSet.append(contentsOf: [newRule])
-        return LSystemRNG(axiom: state, prng: prng, rules: newRuleSet)
+        return LSystemRNG(axiom: axiom, state: state, prng: prng, rules: newRuleSet)
     }
 }

--- a/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
+++ b/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
@@ -1,0 +1,16 @@
+# ``Lindenmayer``
+
+Lindenmayer provides a library you can use and extend to develop your own [Lindenmayer systems](https://en.wikipedia.org/wiki/L-system), in the Swift programming language.
+
+## Overview
+
+While the package includes a number example L-systems, the primary intent is to allow you to create L-systems with rules and modules that you define.
+This implementation provides support for context sensitive, and parametric grammars when creating your L-system.
+
+The library provides 2D and 3D representation rendering of a current L-system states, including some SwiftUI views that you can use to display either 2D or 3D results:
+- The 2D representation uses [Canvas](http://developer.apple.com/documentation/swiftui/Canvas) and [GraphicsContext](https://developer.apple.com/documentation/swiftui/graphicscontext) from [SwiftUI](https://developer.apple.com/documentation/swiftui) on Apple platforms.
+- The 3D representation uses [SceneKit](https://developer.apple.com/documentation/scenekit) on Apple platforms.
+
+The repository has [Discussions](https://github.com/heckj/Lindenmayer/discussions) enabled if you have questions, as well as [issues logged for planned improvements](https://github.com/heckj/Lindenmayer/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement). 
+
+## Topics

--- a/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
+++ b/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
@@ -1,16 +1,19 @@
 # ``Lindenmayer``
 
-Lindenmayer provides a library you can use and extend to develop your own [Lindenmayer systems](https://en.wikipedia.org/wiki/L-system), in the Swift programming language.
+Lindenmayer provides a library to develop and run your own Lindenmayer Systems.
 
 ## Overview
 
-While the package includes a number example L-systems, the primary intent is to allow you to create L-systems with rules and modules that you define.
-This implementation provides support for context sensitive, and parametric grammars when creating your L-system.
+The package includes the core types to support you in building your own Lindenmayer systems (also known as L-systems), and a number examples sourced from Wikipedia and research papers.
+The library provides types and APIs enable you to create L-systems with rules and modules that you define, and renderers to generate 2D and 3D representations of the results.
 
-The library provides 2D and 3D representation rendering of a current L-system states, including some SwiftUI views that you can use to display either 2D or 3D results:
-- The 2D representation uses [Canvas](http://developer.apple.com/documentation/swiftui/Canvas) and [GraphicsContext](https://developer.apple.com/documentation/swiftui/graphicscontext) from [SwiftUI](https://developer.apple.com/documentation/swiftui) on Apple platforms.
-- The 3D representation uses [SceneKit](https://developer.apple.com/documentation/scenekit) on Apple platforms.
+The 2D renderer uses [Canvas](http://developer.apple.com/documentation/swiftui/Canvas) and [GraphicsContext](https://developer.apple.com/documentation/swiftui/graphicscontext) from [SwiftUI](https://developer.apple.com/documentation/swiftui) on Apple platforms.
+The 3D renderer uses [SceneKit](https://developer.apple.com/documentation/scenekit) on Apple platforms.
+The related package ``LindenmayerViews`` provides SwiftUI views that present the results of the renderers.
 
-The repository has [Discussions](https://github.com/heckj/Lindenmayer/discussions) enabled if you have questions, as well as [issues logged for planned improvements](https://github.com/heckj/Lindenmayer/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement). 
+The API provides support for both context free and context sensitive L-system grammars, as well as parametric grammars.
+
+To get support for using this package, see the [Discussions on Github](https://github.com/heckj/Lindenmayer/discussions) for questions and community feedback, or the [Github issue tracker](https://github.com/heckj/Lindenmayer/issues).
+For more information about L-systems, see the Wikipedia page [L-system](https://en.wikipedia.org/wiki/L-system).
 
 ## Topics

--- a/Sources/Lindenmayer/Lindenmayer.swift
+++ b/Sources/Lindenmayer/Lindenmayer.swift
@@ -12,14 +12,14 @@ public enum Lindenmayer {
     /// - Parameters:
     ///   - axiom: An initial module that represents the initial state of the Lindenmayer system..
     static func basic(_ axiom: Module) -> LSystemBasic {
-        return LSystemBasic([axiom])
+        return LSystemBasic([axiom], state: nil)
     }
 
     /// Creates a new Lindenmayer system from an initial state.
     /// - Parameters:
     ///   - axiom: A sequence of modules that represents the initial state of the Lindenmayer system..
     static func basic(_ axiom: [Module]) -> LSystemBasic {
-        return LSystemBasic(axiom)
+        return LSystemBasic(axiom, state: nil)
     }
 
     /// Creates a new Lindenmayer system from an initial state and using the random number generator you provide.
@@ -27,7 +27,7 @@ public enum Lindenmayer {
     ///   - axiom: An initial module that represents the initial state of the Lindenmayer system..
     ///   - prng: A psuedo-random number generator to use for randomness in rule productions.
     static func withRNG<RNGType>(_ axiom: Module, prng: RNGType) -> LSystemRNG<RNGType> {
-        return LSystemRNG(axiom: [axiom], prng: RNGWrapper(prng))
+        return LSystemRNG(axiom: [axiom], state: nil, prng: RNGWrapper(prng))
     }
 
     /// Creates a new Lindenmayer system from an initial state and using the random number generator you provide..
@@ -35,7 +35,7 @@ public enum Lindenmayer {
     ///   - axiom: A sequence of modules that represents the initial state of the Lindenmayer system..
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     static func withRNG<RNGType>(_ axiom: [Module], prng: RNGType) -> LSystemRNG<RNGType> {
-        return LSystemRNG(axiom: axiom, prng: RNGWrapper(prng))
+        return LSystemRNG(axiom: axiom, state: nil, prng: RNGWrapper(prng))
     }
 
     /// Creates a new Lindenmayer system from an initial state, using the random number generator and parameter instance that you provide.
@@ -44,7 +44,7 @@ public enum Lindenmayer {
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
     static func withDefines<PType, RNGType>(_ axiom: Module, prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
-        return LSystemDefinesRNG(axiom: [axiom], parameters: parameters, prng: RNGWrapper(prng), rules: [])
+        return LSystemDefinesRNG(axiom: [axiom], state: nil, parameters: parameters, prng: RNGWrapper(prng), rules: [])
     }
 
     /// Creates a new Lindenmayer system from an initial state, using the random number generator and parameter instance that you provide.
@@ -53,6 +53,6 @@ public enum Lindenmayer {
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
     static func withDefines<PType, RNGType>(_ axiom: [Module], prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
-        return LSystemDefinesRNG(axiom: axiom, parameters: parameters, prng: RNGWrapper(prng), rules: [])
+        return LSystemDefinesRNG(axiom: axiom, state: nil, parameters: parameters, prng: RNGWrapper(prng), rules: [])
     }
 }

--- a/Sources/Lindenmayer/Lindenmayer.swift
+++ b/Sources/Lindenmayer/Lindenmayer.swift
@@ -44,7 +44,7 @@ public enum Lindenmayer {
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
     static func withDefines<PType, RNGType>(_ axiom: Module, prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
-        return LSystemDefinesRNG(axiom: [axiom], state: nil, parameters: parameters, prng: RNGWrapper(prng), rules: [])
+        return LSystemDefinesRNG(axiom: [axiom], state: nil, parameters: PWrapper(parameters), prng: RNGWrapper(prng), rules: [])
     }
 
     /// Creates a new Lindenmayer system from an initial state, using the random number generator and parameter instance that you provide.
@@ -53,6 +53,6 @@ public enum Lindenmayer {
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
     static func withDefines<PType, RNGType>(_ axiom: [Module], prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
-        return LSystemDefinesRNG(axiom: axiom, state: nil, parameters: parameters, prng: RNGWrapper(prng), rules: [])
+        return LSystemDefinesRNG(axiom: axiom, state: nil, parameters: PWrapper(parameters), prng: RNGWrapper(prng), rules: [])
     }
 }

--- a/Sources/Lindenmayer/Module.swift
+++ b/Sources/Lindenmayer/Module.swift
@@ -19,22 +19,22 @@ public protocol Module: CustomStringConvertible {
 }
 
 // MARK: - Default Implementations of computed properties for 2D and 3D rendering commands of a module.
-extension Module {
-    
+
+public extension Module {
     /// The sequence of two-dimensional oriented rendering commands that you use to represent the module.
-    public var render2D: [TwoDRenderCmd] {
+    var render2D: [TwoDRenderCmd] {
         return []
     }
-    
+
     /// The three-dimensional oriented rendering command that you use to represent the module.
-    public var render3D: ThreeDRenderCmd {
+    var render3D: ThreeDRenderCmd {
         return RenderCommand.Ignore()
     }
 }
 
 // MARK: - CustomStringConvertible default implementation
+
 public extension Module {
-    
     /// Returns a string description for this module.
     var description: String {
         let resovledName: String
@@ -46,4 +46,3 @@ public extension Module {
         return resovledName
     }
 }
-

--- a/Sources/Lindenmayer/PWrapper.swift
+++ b/Sources/Lindenmayer/PWrapper.swift
@@ -1,6 +1,6 @@
 //
 //  PWrapper.swift
-//  
+//
 //
 //  Created by Joseph Heck on 1/4/22.
 //
@@ -15,11 +15,11 @@ public final class PWrapper<PType> {
     public func update(_ p: PType) {
         _parameters = p
     }
-    
+
     public func unwrap() -> PType {
         return _parameters
     }
-    
+
     /// Creates a new random number generator wrapper class with the random number generator you provide.
     /// - Parameter prng: A random number generator.
     public init(_ p: PType) {

--- a/Sources/Lindenmayer/PWrapper.swift
+++ b/Sources/Lindenmayer/PWrapper.swift
@@ -1,0 +1,28 @@
+//
+//  PWrapper.swift
+//  
+//
+//  Created by Joseph Heck on 1/4/22.
+//
+
+import Foundation
+import Squirrel3
+
+/// A class that provides reference semantics to accessing an parameters value type.
+public final class PWrapper<PType> {
+    private var _parameters: PType
+
+    public func update(_ p: PType) {
+        _parameters = p
+    }
+    
+    public func unwrap() -> PType {
+        return _parameters
+    }
+    
+    /// Creates a new random number generator wrapper class with the random number generator you provide.
+    /// - Parameter prng: A random number generator.
+    public init(_ p: PType) {
+        _parameters = p
+    }
+}

--- a/Sources/Lindenmayer/RNGWrapper.swift
+++ b/Sources/Lindenmayer/RNGWrapper.swift
@@ -6,11 +6,30 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A class that provides probabilistic functions based on the seedable psuedo-random number generator used to create it.
-public final class RNGWrapper<PRNG> where PRNG: RandomNumberGenerator {
-    var _prng: PRNG
+public final class RNGWrapper<PRNG> where PRNG: SeededRandomNumberGenerator {
+    private var _prng: PRNG
+#if DEBUG
     var _invokeCount: UInt64 = 0
+#endif
+    // access to the underlying PRNG state
+    
+    public var seed: UInt64 {
+        self._prng.seed
+    }
+    
+    public var position: UInt64 {
+        self._prng.position
+    }
+    
+    public func resetRNG(seed: UInt64) {
+        self._prng = PRNG.init(seed: seed)
+#if DEBUG
+        _invokeCount = 0
+#endif
+    }
     
     /// Creates a new random number generator wrapper class with the random number generator you provide.
     /// - Parameter prng: A random number generator.
@@ -21,21 +40,27 @@ public final class RNGWrapper<PRNG> where PRNG: RandomNumberGenerator {
     /// Returns a random float value within the range you provide.
     /// - Parameter range: The range of possible values for the float.
     func randomFloat(in range: ClosedRange<Float>) -> Float {
+#if DEBUG
         _invokeCount += 1
+#endif
         return Float.random(in: range, using: &_prng)
     }
 
     /// Returns a random integer from within the range you provide.
     /// - Parameter range: The range of possible values for the integer.
     func randomInt(in range: ClosedRange<Int>) -> Int {
+#if DEBUG
         _invokeCount += 1
+#endif
         return Int.random(in: range, using: &_prng)
     }
 
     /// Returns a single module randomly selected from the list you provide.
     /// - Parameter from: The sequence of modules to choose from.
     func select(_ from: [Module]) -> Module {
+#if DEBUG
         _invokeCount += 1
+#endif
         return from.randomElement(using: &_prng)!
     }
 
@@ -43,7 +68,9 @@ public final class RNGWrapper<PRNG> where PRNG: RandomNumberGenerator {
     ///
     /// Also known as a "coin-toss".
     func randomBool() -> Bool {
+#if DEBUG
         _invokeCount += 1
+#endif
         return Bool.random(using: &_prng)
     }
 
@@ -58,7 +85,9 @@ public final class RNGWrapper<PRNG> where PRNG: RandomNumberGenerator {
 
     /// Returns a random float value between 0.0 and 1.0.
     func p() -> Float {
+#if DEBUG
         _invokeCount += 1
+#endif
         return Float.random(in: 0.0 ... 1.0, using: &_prng)
     }
 }

--- a/Sources/Lindenmayer/RNGWrapper.swift
+++ b/Sources/Lindenmayer/RNGWrapper.swift
@@ -11,26 +11,26 @@ import Squirrel3
 /// A class that provides probabilistic functions based on the seedable psuedo-random number generator used to create it.
 public final class RNGWrapper<PRNG> where PRNG: SeededRandomNumberGenerator {
     private var _prng: PRNG
-#if DEBUG
-    var _invokeCount: UInt64 = 0
-#endif
+    #if DEBUG
+        var _invokeCount: UInt64 = 0
+    #endif
     // access to the underlying PRNG state
-    
+
     public var seed: UInt64 {
-        self._prng.seed
+        _prng.seed
     }
-    
+
     public var position: UInt64 {
-        self._prng.position
+        _prng.position
     }
-    
+
     public func resetRNG(seed: UInt64) {
-        self._prng = PRNG.init(seed: seed)
-#if DEBUG
-        _invokeCount = 0
-#endif
+        _prng = PRNG(seed: seed)
+        #if DEBUG
+            _invokeCount = 0
+        #endif
     }
-    
+
     /// Creates a new random number generator wrapper class with the random number generator you provide.
     /// - Parameter prng: A random number generator.
     public init(_ prng: PRNG) {
@@ -40,27 +40,27 @@ public final class RNGWrapper<PRNG> where PRNG: SeededRandomNumberGenerator {
     /// Returns a random float value within the range you provide.
     /// - Parameter range: The range of possible values for the float.
     func randomFloat(in range: ClosedRange<Float>) -> Float {
-#if DEBUG
-        _invokeCount += 1
-#endif
+        #if DEBUG
+            _invokeCount += 1
+        #endif
         return Float.random(in: range, using: &_prng)
     }
 
     /// Returns a random integer from within the range you provide.
     /// - Parameter range: The range of possible values for the integer.
     func randomInt(in range: ClosedRange<Int>) -> Int {
-#if DEBUG
-        _invokeCount += 1
-#endif
+        #if DEBUG
+            _invokeCount += 1
+        #endif
         return Int.random(in: range, using: &_prng)
     }
 
     /// Returns a single module randomly selected from the list you provide.
     /// - Parameter from: The sequence of modules to choose from.
     func select(_ from: [Module]) -> Module {
-#if DEBUG
-        _invokeCount += 1
-#endif
+        #if DEBUG
+            _invokeCount += 1
+        #endif
         return from.randomElement(using: &_prng)!
     }
 
@@ -68,9 +68,9 @@ public final class RNGWrapper<PRNG> where PRNG: SeededRandomNumberGenerator {
     ///
     /// Also known as a "coin-toss".
     func randomBool() -> Bool {
-#if DEBUG
-        _invokeCount += 1
-#endif
+        #if DEBUG
+            _invokeCount += 1
+        #endif
         return Bool.random(using: &_prng)
     }
 
@@ -85,9 +85,9 @@ public final class RNGWrapper<PRNG> where PRNG: SeededRandomNumberGenerator {
 
     /// Returns a random float value between 0.0 and 1.0.
     func p() -> Float {
-#if DEBUG
-        _invokeCount += 1
-#endif
+        #if DEBUG
+            _invokeCount += 1
+        #endif
         return Float.random(in: 0.0 ... 1.0, using: &_prng)
     }
 }

--- a/Sources/Lindenmayer/RenderCommands.swift
+++ b/Sources/Lindenmayer/RenderCommands.swift
@@ -60,7 +60,6 @@ public enum TurtleCodes: String {
     case cylinder = "||"
     case cone = "/\\"
     case sphere = "o"
-    
 }
 
 // MARK: - RENDERING COMMAND PROTOCOLS -
@@ -94,7 +93,7 @@ public enum RenderCommand {
 
     public struct Move: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.move.rawValue
-        
+
         public let length: Double
         public init(length: Double) {
             self.length = length
@@ -103,7 +102,7 @@ public enum RenderCommand {
 
     public struct Draw: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.draw.rawValue
-        
+
         public let length: Double
         public init(length: Double) {
             self.length = length
@@ -112,7 +111,7 @@ public enum RenderCommand {
 
     public struct TurnLeft: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.leftTurn.rawValue
-        
+
         public let angle: Double
         public init(angle: Double) {
             self.angle = angle
@@ -121,7 +120,7 @@ public enum RenderCommand {
 
     public struct TurnRight: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.rightTurn.rawValue
-        
+
         public let angle: Double
         public init(angle: Double) {
             self.angle = angle
@@ -139,7 +138,6 @@ public enum RenderCommand {
         public init(width: Double) {
             self.width = width
         }
-
     }
 
     public struct SetColor: TwoDRenderCmd {
@@ -148,7 +146,6 @@ public enum RenderCommand {
         public init(representation: ColorRepresentation) {
             self.representation = representation
         }
-
     }
 
     public struct PitchUp: ThreeDRenderCmd {
@@ -157,7 +154,6 @@ public enum RenderCommand {
         public init(angle: Double) {
             self.angle = angle
         }
-
     }
 
     public struct PitchDown: ThreeDRenderCmd {
@@ -166,7 +162,6 @@ public enum RenderCommand {
         public init(angle: Double) {
             self.angle = angle
         }
-
     }
 
     public struct RollRight: ThreeDRenderCmd {
@@ -175,7 +170,6 @@ public enum RenderCommand {
         public init(angle: Double) {
             self.angle = angle
         }
-
     }
 
     public struct RollLeft: ThreeDRenderCmd {
@@ -184,7 +178,6 @@ public enum RenderCommand {
         public init(angle: Double) {
             self.angle = angle
         }
-
     }
 
     public struct SpinToFlat: ThreeDRenderCmd {
@@ -205,7 +198,6 @@ public enum RenderCommand {
             self.radius = radius
             self.color = color
         }
-
     }
 
     public struct Cone: ThreeDRenderCmd {
@@ -220,7 +212,6 @@ public enum RenderCommand {
             self.radiusBottom = radiusBottom
             self.color = color
         }
-
     }
 
     public struct Sphere: ThreeDRenderCmd {
@@ -232,7 +223,7 @@ public enum RenderCommand {
             self.color = color
         }
     }
-    
+
     // 2D ONLY
     public static var setLineWidth = SetLineWidth(width: 1)
     public static var setColor = SetColor(representation: ColorRepresentation(r: 0.0, g: 0.0, b: 0.0))
@@ -240,22 +231,22 @@ public enum RenderCommand {
     // 2D and 3D
     public static var move = Move(length: 1.0)
     public static var draw = Draw(length: 1.0)
-    
+
     public static var turnLeft = TurnLeft(angle: 90)
     public static var turnRight = TurnRight(angle: 90)
-    
+
     public static var branch = Branch()
     public static var endBranch = EndBranch()
-    
+
     // 3D ONLY
     public static var pitchUp = PitchUp(angle: 30)
     public static var pitchDown = PitchDown(angle: 30)
-    
+
     public static var rollRight = RollRight(angle: 90)
     public static var rollLeft = RollLeft(angle: 90)
-    
+
     public static var spinToFlat = SpinToFlat()
-    
+
     public static var cylinder = Cylinder(length: 1, radius: 0.1)
     public static var cone = Cone(length: 1, radiusTop: 0, radiusBottom: 0.1)
     public static var sphere = Sphere(radius: 0.1)

--- a/Sources/Lindenmayer/RewriteRuleDirectDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectDefines.swift
@@ -12,7 +12,7 @@ public struct RewriteRuleDirectDefines<DC, PType>: Rule where DC: Module {
     public var parametricEval: ((DC, PType) -> Bool)?
 
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     /// The signature of the produce closure that provides a module and expects a sequence of modules.
     public typealias singleMatchProducesList = (DC, PType) -> [Module]
@@ -29,7 +29,7 @@ public struct RewriteRuleDirectDefines<DC, PType>: Rule where DC: Module {
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType direct: DC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 where _: ((DC, PType) -> Bool)?,
                 produces singleModuleProduce: @escaping singleMatchProducesList)
     {
@@ -54,7 +54,7 @@ public struct RewriteRuleDirectDefines<DC, PType>: Rule where DC: Module {
             guard let directInstance = matchSet.directInstance as? DC else {
                 return false
             }
-            return additionalEval(directInstance, parameters)
+            return additionalEval(directInstance, parameters.unwrap())
         }
 
         return true
@@ -67,7 +67,7 @@ public struct RewriteRuleDirectDefines<DC, PType>: Rule where DC: Module {
         guard let directInstance = matchSet.directInstance as? DC else {
             return []
         }
-        return produceClosure(directInstance, parameters)
+        return produceClosure(directInstance, parameters.unwrap())
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
@@ -13,7 +13,7 @@ public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Modul
     public var parametricEval: ((DC, PType) -> Bool)?
 
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -33,7 +33,7 @@ public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Modul
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType direct: DC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((DC, PType) -> Bool)?,
                 produces singleModuleProduce: @escaping singleMatchProducesList)
@@ -61,7 +61,7 @@ public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Modul
                 return false
             }
 
-            return additionalEval(directInstance, parameters)
+            return additionalEval(directInstance, parameters.unwrap())
         }
 
         return true
@@ -74,7 +74,7 @@ public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Modul
         guard let directInstance = matchSet.directInstance as? DC else {
             return []
         }
-        return produceClosure(directInstance, parameters, prng)
+        return produceClosure(directInstance, parameters.unwrap(), prng)
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Module, PRNG: SeededRandomNumberGenerator {
     public var parametricEval: ((DC, PType) -> Bool)?
 
     /// The set of parameters provided by the L-system for rule evaluation and production.

--- a/Sources/Lindenmayer/RewriteRuleDirectRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRNG.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleDirectRNG<DC, PRNG>: Rule where DC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleDirectRNG<DC, PRNG>: Rule where DC: Module, PRNG: SeededRandomNumberGenerator {
     public var parametricEval: ((DC) -> Bool)?
 
     /// A psuedo-random number generator to use for stochastic rule productions.

--- a/Sources/Lindenmayer/RewriteRuleDirectRightDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightDefines.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleDirectRightDefines<DC, RC, PType>: Rule where DC: Module, RC: Module {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     public var parametricEval: ((DC, RC, PType) -> Bool)?
 
@@ -29,7 +29,7 @@ public struct RewriteRuleDirectRightDefines<DC, RC, PType>: Rule where DC: Modul
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType: DC.Type, rightType: RC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 where _: ((DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
     {
@@ -58,7 +58,7 @@ public struct RewriteRuleDirectRightDefines<DC, RC, PType>: Rule where DC: Modul
             else {
                 return false
             }
-            return additionalEval(directInstance, rightInstance, parameters)
+            return additionalEval(directInstance, rightInstance, parameters.unwrap())
         }
 
         return true
@@ -73,7 +73,7 @@ public struct RewriteRuleDirectRightDefines<DC, RC, PType>: Rule where DC: Modul
         else {
             return []
         }
-        return produceClosure(directInstance, rightInstance, parameters)
+        return produceClosure(directInstance, rightInstance, parameters.unwrap())
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
@@ -6,9 +6,9 @@
 //
 
 import Foundation
-
+import Squirrel3
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where DC: Module, RC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
     var parameters: PType
 

--- a/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
@@ -10,7 +10,7 @@ import Squirrel3
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -32,7 +32,7 @@ public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where 
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType: DC.Type, rightType: RC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
@@ -63,7 +63,7 @@ public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where 
             else {
                 return false
             }
-            return additionalEval(directInstance, rightInstance, parameters)
+            return additionalEval(directInstance, rightInstance, parameters.unwrap())
         }
 
         return true
@@ -78,7 +78,7 @@ public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where 
         else {
             return []
         }
-        return produceClosure(directInstance, rightInstance, parameters, prng)
+        return produceClosure(directInstance, rightInstance, parameters.unwrap(), prng)
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleDirectRightRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightRNG.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleDirectRightRNG<DC, RC, PRNG>: Rule where DC: Module, RC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleDirectRightRNG<DC, RC, PRNG>: Rule where DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectDefines.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectDefines<LC, DC, PType>: Rule where LC: Module, DC: Module {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     public var parametricEval: ((LC, DC, PType) -> Bool)?
 
@@ -29,7 +29,7 @@ public struct RewriteRuleLeftDirectDefines<LC, DC, PType>: Rule where LC: Module
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 where _: ((LC, DC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
     {
@@ -59,7 +59,7 @@ public struct RewriteRuleLeftDirectDefines<LC, DC, PType>: Rule where LC: Module
             else {
                 return false
             }
-            return additionalEval(leftInstance, directInstance, parameters)
+            return additionalEval(leftInstance, directInstance, parameters.unwrap())
         }
 
         return true
@@ -75,7 +75,7 @@ public struct RewriteRuleLeftDirectDefines<LC, DC, PType>: Rule where LC: Module
         else {
             return []
         }
-        return produceClosure(leftInstance, directInstance, parameters)
+        return produceClosure(leftInstance, directInstance, parameters.unwrap())
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
@@ -11,7 +11,7 @@ import Squirrel3
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where LC: Module, DC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -33,7 +33,7 @@ public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where L
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((LC, DC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
@@ -65,7 +65,7 @@ public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where L
             else {
                 return false
             }
-            return additionalEval(leftInstance, directInstance, parameters)
+            return additionalEval(leftInstance, directInstance, parameters.unwrap())
         }
 
         return true
@@ -80,7 +80,7 @@ public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where L
         else {
             return []
         }
-        return produceClosure(leftInstance, directInstance, parameters, prng)
+        return produceClosure(leftInstance, directInstance, parameters.unwrap(), prng)
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where LC: Module, DC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where LC: Module, DC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
     var parameters: PType
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRNG.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleLeftDirectRNG<LC, DC, PRNG>: Rule where LC: Module, DC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleLeftDirectRNG<LC, DC, PRNG>: Rule where LC: Module, DC: Module, PRNG: SeededRandomNumberGenerator {
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefines.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectRightDefines<LC, DC, RC, PType>: Rule where LC: Module, DC: Module, RC: Module {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     public var parametricEval: ((LC, DC, RC, PType) -> Bool)?
 
@@ -29,7 +29,7 @@ public struct RewriteRuleLeftDirectRightDefines<LC, DC, RC, PType>: Rule where L
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type, rightType: RC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 where _: ((LC, DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
     {
@@ -60,7 +60,7 @@ public struct RewriteRuleLeftDirectRightDefines<LC, DC, RC, PType>: Rule where L
                   let directInstance = matchSet.directInstance as? DC,
                   let rightInstance = matchSet.rightInstance as? RC
             else { return false }
-            return additionalEval(leftInstance, directInstance, rightInstance, parameters)
+            return additionalEval(leftInstance, directInstance, rightInstance, parameters.unwrap())
         }
 
         return true
@@ -76,7 +76,7 @@ public struct RewriteRuleLeftDirectRightDefines<LC, DC, RC, PType>: Rule where L
         else {
             return []
         }
-        return produceClosure(leftInstance, directInstance, rightInstance, parameters)
+        return produceClosure(leftInstance, directInstance, rightInstance, parameters.unwrap())
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
@@ -11,7 +11,7 @@ import Squirrel3
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rule where LC: Module, DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PType
+    var parameters: PWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -33,7 +33,7 @@ public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rul
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type, rightType: RC.Type,
-                parameters: PType,
+                parameters: PWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((LC, DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
@@ -66,7 +66,7 @@ public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rul
                   let directInstance = matchSet.directInstance as? DC,
                   let rightInstance = matchSet.rightInstance as? RC
             else { return false }
-            return additionalEval(leftInstance, directInstance, rightInstance, parameters)
+            return additionalEval(leftInstance, directInstance, rightInstance, parameters.unwrap())
         }
 
         return true
@@ -82,7 +82,7 @@ public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rul
         else {
             return []
         }
-        return produceClosure(leftInstance, directInstance, rightInstance, parameters, prng)
+        return produceClosure(leftInstance, directInstance, rightInstance, parameters.unwrap(), prng)
     }
 }
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rule where LC: Module, DC: Module, RC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rule where LC: Module, DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
     var parameters: PType
 

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightRNG.swift
@@ -6,9 +6,10 @@
 //
 
 import Foundation
+import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
-public struct RewriteRuleLeftDirectRightRNG<LC, DC, RC, PRNG>: Rule where LC: Module, DC: Module, RC: Module, PRNG: RandomNumberGenerator {
+public struct RewriteRuleLeftDirectRightRNG<LC, DC, RC, PRNG>: Rule where LC: Module, DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
 

--- a/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
+++ b/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
@@ -1,6 +1,6 @@
 //
 //  File.swift
-//  
+//
 //
 //  Created by Joseph Heck on 1/3/22.
 //
@@ -44,4 +44,3 @@ extension simd_float4x4 {
         return calc_angle
     }
 }
-

--- a/Sources/Lindenmayer/SceneKitRenderer.swift
+++ b/Sources/Lindenmayer/SceneKitRenderer.swift
@@ -132,7 +132,7 @@ public struct SceneKitRenderer {
                     currentState = currentState.applyingTransform(yawTransform)
                     print("Pitch (rotate around +X Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
                 }
-                
+
             case TurtleCodes.pitchDown.rawValue:
                 // negative values pitch nose down
                 if let cmd = cmd as? RenderCommand.PitchDown {
@@ -212,22 +212,22 @@ public struct SceneKitRenderer {
 //                    print("Updated transform:")
 //                    print(currentState.transform.prettyPrintString("  "))
                 }
-                
+
             case TurtleCodes.move.rawValue:
                 if let cmd = cmd as? RenderCommand.Move {
                     let moveTransform = translationTransform(x: 0, y: Float(cmd.length), z: 0)
                     currentState = currentState.applyingTransform(moveTransform)
                     print("Moving +y by \(cmd.length) -> \(String(describing: currentState.transform))")
                 }
-                
+
             case TurtleCodes.branch.rawValue:
                 stateStack.append(currentState)
                 print("Saving state: \(String(describing: currentState.transform))")
-                
+
             case TurtleCodes.endBranch.rawValue:
                 currentState = stateStack.removeLast()
                 print("Restored state to: \(String(describing: currentState.transform))")
-            
+
             case TurtleCodes.cylinder.rawValue:
                 if let cmd = cmd as? RenderCommand.Cylinder {
                     let node = SCNNode(geometry: SCNCylinder(radius: cmd.radius, height: cmd.length))
@@ -237,7 +237,7 @@ public struct SceneKitRenderer {
 
                     // Nudge the cylinder "up" so that its bottom is at the "origin" of the transform.
                     let nudgeOriginTransform = translationTransform(x: 0, y: Float(cmd.length / 2.0), z: 0)
-    //                print(" - calc nudgeTransform: \(nudgeOriginTransform)")
+                    //                print(" - calc nudgeTransform: \(nudgeOriginTransform)")
                     node.simdTransform = matrix_multiply(currentState.transform, nudgeOriginTransform)
 
                     scene.rootNode.addChildNode(node)
@@ -248,8 +248,7 @@ public struct SceneKitRenderer {
                     currentState = currentState.applyingTransform(moveStateTransform)
 
                     print("Added cylinder (r=\(cmd.radius)) by \(cmd.length) at \(String(describing: node.simdTransform))")
-    //                print("Moving +y by \(cmd.length) -> \(String(describing: currentState.transform))")
-
+                    //                print("Moving +y by \(cmd.length) -> \(String(describing: currentState.transform))")
                 }
             case TurtleCodes.cone.rawValue:
                 if let cmd = cmd as? RenderCommand.Cone {
@@ -270,8 +269,7 @@ public struct SceneKitRenderer {
                     currentState = currentState.applyingTransform(moveStateTransform)
 
                     print("Added cone (tr=\(cmd.radiusTop), br=\(cmd.radiusBottom) by \(cmd.length) at \(String(describing: node.simdTransform))")
-    //                print("Moving +y by \(cmd.length) -> \(String(describing: currentState.transform))")
-
+                    //                print("Moving +y by \(cmd.length) -> \(String(describing: currentState.transform))")
                 }
             case TurtleCodes.sphere.rawValue:
                 if let cmd = cmd as? RenderCommand.Sphere {
@@ -289,7 +287,7 @@ public struct SceneKitRenderer {
                     currentState = currentState.applyingTransform(moveStateTransform)
 
                     print("Added sphere (r=\(cmd.radius)) at \(String(describing: node.simdTransform))")
-    //                print("Moving +y by \(radius) -> \(String(describing: currentState.transform))")
+                    //                print("Moving +y by \(radius) -> \(String(describing: currentState.transform))")
                 }
             default: // ignore
                 break
@@ -308,5 +306,4 @@ public struct SceneKitRenderer {
     func degrees(radians: Float) -> Float {
         return radians / .pi * 180.0
     }
-
 }

--- a/Sources/LindenmayerViews/DynamicLSystemView.swift
+++ b/Sources/LindenmayerViews/DynamicLSystemView.swift
@@ -33,7 +33,7 @@ public struct DynamicLSystemView: View {
                 }
             }
             .padding()
-            Lsystem2DView(system: selectedSystem.evolved(iterations: Int(evolutions)))
+            Lsystem2DView(system: selectedSystem.lsystem.evolved(iterations: Int(evolutions)))
         }
     }
 }

--- a/Sources/LindenmayerViews/LindenmayerViews.docc/LindenmayerViews.md
+++ b/Sources/LindenmayerViews/LindenmayerViews.docc/LindenmayerViews.md
@@ -1,0 +1,9 @@
+# ``LindenmayerViews``
+
+LindenmayerViews provides a collection of SwiftUI views to display the results 2D and 3D L-systems that you create with ``Lindenmayer``.
+
+## Overview
+
+
+
+## Topics

--- a/Sources/LindenmayerViews/Lsystem2DView.swift
+++ b/Sources/LindenmayerViews/Lsystem2DView.swift
@@ -29,6 +29,6 @@ public struct Lsystem2DView: View {
 @available(macOS 12.0, *)
 struct Lsystem2DView_Previews: PreviewProvider {
     static var previews: some View {
-        Lsystem2DView(system: Examples2D.barnsleyFern.evolved(iterations: 4))
+        Lsystem2DView(system: Examples2D.barnsleyFern.lsystem.evolved(iterations: 4))
     }
 }

--- a/Sources/LindenmayerViews/Lsystem3DView.swift
+++ b/Sources/LindenmayerViews/Lsystem3DView.swift
@@ -65,6 +65,6 @@ public struct Lsystem3DView: View {
 
 struct Lsystem3DView_Previews: PreviewProvider {
     static var previews: some View {
-        Lsystem3DView(system: Examples3D.algae3D.evolved(iterations: 3))
+        Lsystem3DView(system: Examples3D.algae3D.lsystem.evolved(iterations: 3))
     }
 }

--- a/Tests/LindenmayerTests/GraphicsContextRendererTests.swift
+++ b/Tests/LindenmayerTests/GraphicsContextRendererTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class GraphicsContextRendererTests: XCTestCase {
     func testLSystem_boundingRectCalc() throws {
         let tree = Examples2D.kochCurve
-        let evo1 = try tree.lsystem.evolve(iterations: 3)
+        let evo1 = tree.lsystem.evolved(iterations: 3)
         let path: CGRect = GraphicsContextRenderer().calcBoundingRect(system: evo1)
         // print(path)
         // print("Size: \(path.size) -> height: \(path.size.height), width: \(path.size.width)")

--- a/Tests/LindenmayerTests/LSystemTests.swift
+++ b/Tests/LindenmayerTests/LSystemTests.swift
@@ -15,7 +15,7 @@ final class LSystemTests: XCTestCase {
         XCTAssertEqual(result[0].render2D[0].name, RenderCommand.Draw(length: 10).name)
         XCTAssertEqual(result[0].render3D.name, RenderCommand.Ignore().name)
 
-        let updated = try x.evolve()
+        let updated = x.evolve()
         XCTAssertEqual(updated.state.count, 1)
         let downcast = updated.state[0] as! Modules.Internode
         XCTAssertEqual(downcast.description, "I")
@@ -27,7 +27,7 @@ final class LSystemTests: XCTestCase {
         XCTAssertEqual(algae.state.count, 1)
         XCTAssertEqual(algae.state.map { $0.description }.joined(), "A")
 
-        let iter1 = try algae.evolve() // debugPrint: true
+        let iter1 = algae.evolve() // debugPrint: true
         XCTAssertEqual(iter1.state.count, 2)
 
         XCTAssertEqual(iter1.state[0].description, "A")
@@ -40,10 +40,10 @@ final class LSystemTests: XCTestCase {
     func testAlgaeLSystem_evolve2() throws {
         var resultSequence = ""
         let algae = Examples2D.algae.lsystem
-        let iter2 = try algae.evolve()
+        let iter2 = algae.evolve()
         resultSequence = iter2.state.map { $0.description }.joined()
         XCTAssertEqual(resultSequence, "AB")
-        let iter3 = try iter2.evolve() // debugPrint: true
+        let iter3 = iter2.evolve() // debugPrint: true
         resultSequence = iter3.state.map { $0.description }.joined()
         XCTAssertEqual(resultSequence, "ABA")
     }
@@ -51,25 +51,25 @@ final class LSystemTests: XCTestCase {
     func testAlgaeLSystem_evolve3() throws {
         var resultSequence = ""
         let algae = Examples2D.algae.lsystem
-        let evolution = try algae.evolve(iterations: 3)
+        let evolution = algae.evolved(iterations: 3)
         resultSequence = evolution.state.map { $0.description }.joined()
         XCTAssertEqual(resultSequence, "ABAAB")
-        let evolution2 = try evolution.evolve()
+        let evolution2 = evolution.evolve()
         resultSequence = evolution2.state.map { $0.description }.joined()
         XCTAssertEqual(resultSequence, "ABAABABA")
     }
 
     func testFractalTree_evolve2() throws {
         let tree = Examples2D.fractalTree.lsystem
-        let evo1 = try tree.evolve()
+        let evo1 = tree.evolve()
         XCTAssertEqual(evo1.state.map { $0.description }.joined(), "I[+L]-L")
-        let evo2 = try evo1.evolve()
+        let evo2 = evo1.evolve()
         XCTAssertEqual(evo2.state.map { $0.description }.joined(), "II[+I[+L]-L]-I[+L]-L")
     }
 
     func testLSystem_kochCurve() throws {
         let tree = Examples2D.kochCurve.lsystem
-        let evo1 = try tree.evolve(iterations: 3)
+        let evo1 = tree.evolved(iterations: 3)
         XCTAssertEqual(evo1.state.map { $0.description }.joined(),
                        "F+F-F-F+F+F+F-F-F+F-F+F-F-F+F-F+F-F-F+F+F+F-F-F+F+F+F-F-F+F+F+F-F-F+F-F+F-F-F+F-F+F-F-F+F+F+F-F-F+F-F+F-F-F+F+F+F-F-F+F-F+F-F-F+F-F+F-F-F+F+F+F-F-F+F-F+F-F-F+F+F+F-F-F+F-F+F-F-F+F-F+F-F-F+F+F+F-F-F+F+F+F-F-F+F+F+F-F-F+F-F+F-F-F+F-F+F-F-F+F+F+F-F-F+F")
     }

--- a/Tests/LindenmayerTests/LSystemTests.swift
+++ b/Tests/LindenmayerTests/LSystemTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class LSystemTests: XCTestCase {
     func testLSystemDefault() throws {
-        let x = LSystemRNG<PRNG>(axiom: [Modules.Internode()], prng: RNGWrapper(PRNG(seed: 0)))
+        let x = LSystemRNG<PRNG>(axiom: [Modules.Internode()], state: nil, prng: RNGWrapper(PRNG(seed: 0)))
         XCTAssertNotNil(x)
 
         let result = x.state

--- a/Tests/LindenmayerTests/PRNGWrapperTests.swift
+++ b/Tests/LindenmayerTests/PRNGWrapperTests.swift
@@ -87,7 +87,7 @@ final class PRNGWrapperTests: XCTestCase {
         XCTAssertEqual(start.prng._invokeCount, 0)
 
         let oneEv = start.evolve()
-        
+
         XCTAssertEqual(oneEv.prng.seed, 42)
         XCTAssertEqual(oneEv.prng._invokeCount, 2)
 

--- a/Tests/LindenmayerTests/PRNGWrapperTests.swift
+++ b/Tests/LindenmayerTests/PRNGWrapperTests.swift
@@ -62,23 +62,20 @@ final class PRNGWrapperTests: XCTestCase {
         XCTAssertEqual(start.prng._invokeCount, 0)
 
         let oneEv = start.evolve()
-        let downcastOneEv = oneEv as! LSystemRNG<PRNG>
-        XCTAssertEqual(downcastOneEv.prng.seed, 42)
-        XCTAssertEqual(downcastOneEv.prng._invokeCount, 2)
-        // print(downcastOneEv.prng._prng.position)
+        XCTAssertEqual(oneEv.prng.seed, 42)
+        XCTAssertEqual(oneEv.prng._invokeCount, 2)
+        // print(oneEv.prng.position)
 
         let sideTest = RNGWrapper(PRNG(seed: 42))
         _ = sideTest.p()
         _ = sideTest.p()
         XCTAssertEqual(sideTest._invokeCount, 2)
-        XCTAssertEqual(sideTest.position, downcastOneEv.prng.position)
+        XCTAssertEqual(sideTest.position, oneEv.prng.position)
 
         let twoEv = oneEv.evolve()
-        let downcastTwoEv = twoEv as! LSystemRNG<PRNG>
         // Even though evolve is returning a new LSystem, the underlying reference to the RNG should be the same - so it
         // continues to move forward as new evolutions are invoked.
-        XCTAssertEqual(downcastTwoEv.prng._invokeCount, 4)
-        XCTAssertEqual(downcastOneEv.prng._invokeCount, 4)
+        XCTAssertEqual(twoEv.prng._invokeCount, 4)
         start.prng.resetRNG(seed: start.prng.seed)
     }
 
@@ -90,13 +87,13 @@ final class PRNGWrapperTests: XCTestCase {
         XCTAssertEqual(start.prng._invokeCount, 0)
 
         let oneEv = start.evolve()
-        let downcastOneEv = oneEv as! LSystemRNG<PRNG>
-        XCTAssertEqual(downcastOneEv.prng.seed, 42)
-        XCTAssertEqual(downcastOneEv.prng._invokeCount, 2)
+        
+        XCTAssertEqual(oneEv.prng.seed, 42)
+        XCTAssertEqual(oneEv.prng._invokeCount, 2)
 
         start.prng.resetRNG(seed: start.prng.seed)
-        XCTAssertEqual(downcastOneEv.prng.seed, 42)
-        XCTAssertEqual(downcastOneEv.prng.position, 42)
-        XCTAssertEqual(downcastOneEv.prng._invokeCount, 0)
+        XCTAssertEqual(oneEv.prng.seed, 42)
+        XCTAssertEqual(oneEv.prng.position, 42)
+        XCTAssertEqual(oneEv.prng._invokeCount, 0)
     }
 }

--- a/Tests/LindenmayerTests/PRNGWrapperTests.swift
+++ b/Tests/LindenmayerTests/PRNGWrapperTests.swift
@@ -61,7 +61,7 @@ final class PRNGWrapperTests: XCTestCase {
         XCTAssertEqual(start.prng._prng.seed, 42)
         XCTAssertEqual(start.prng._invokeCount, 0)
 
-        let oneEv = try start.evolve()
+        let oneEv = start.evolve()
         let downcastOneEv = oneEv as! LSystemRNG<PRNG>
         XCTAssertEqual(downcastOneEv.prng._prng.seed, 42)
         XCTAssertEqual(downcastOneEv.prng._invokeCount, 2)
@@ -73,7 +73,7 @@ final class PRNGWrapperTests: XCTestCase {
         XCTAssertEqual(sideTest._invokeCount, 2)
         XCTAssertEqual(sideTest._prng.position, downcastOneEv.prng._prng.position)
 
-        let twoEv = try oneEv.evolve()
+        let twoEv = oneEv.evolve()
         let downcastTwoEv = twoEv as! LSystemRNG<PRNG>
         // Even though evolve is returning a new LSystem, the underlying reference to the RNG should be the same - so it
         // continues to move forward as new evolutions are invoked.

--- a/Tests/LindenmayerTests/PRNGWrapperTests.swift
+++ b/Tests/LindenmayerTests/PRNGWrapperTests.swift
@@ -58,12 +58,12 @@ final class PRNGWrapperTests: XCTestCase {
         // requires `@testable import Lindenmayer` to get to the DetailedExamples struct
         let start = Detailed3DExamples.randomBush
 
-        XCTAssertEqual(start.prng._prng.seed, 42)
+        XCTAssertEqual(start.prng.seed, 42)
         XCTAssertEqual(start.prng._invokeCount, 0)
 
         let oneEv = start.evolve()
         let downcastOneEv = oneEv as! LSystemRNG<PRNG>
-        XCTAssertEqual(downcastOneEv.prng._prng.seed, 42)
+        XCTAssertEqual(downcastOneEv.prng.seed, 42)
         XCTAssertEqual(downcastOneEv.prng._invokeCount, 2)
         // print(downcastOneEv.prng._prng.position)
 
@@ -71,7 +71,7 @@ final class PRNGWrapperTests: XCTestCase {
         _ = sideTest.p()
         _ = sideTest.p()
         XCTAssertEqual(sideTest._invokeCount, 2)
-        XCTAssertEqual(sideTest._prng.position, downcastOneEv.prng._prng.position)
+        XCTAssertEqual(sideTest.position, downcastOneEv.prng.position)
 
         let twoEv = oneEv.evolve()
         let downcastTwoEv = twoEv as! LSystemRNG<PRNG>
@@ -79,5 +79,24 @@ final class PRNGWrapperTests: XCTestCase {
         // continues to move forward as new evolutions are invoked.
         XCTAssertEqual(downcastTwoEv.prng._invokeCount, 4)
         XCTAssertEqual(downcastOneEv.prng._invokeCount, 4)
+        start.prng.resetRNG(seed: start.prng.seed)
+    }
+    
+    func testResettingPRNG() throws {
+        // requires `@testable import Lindenmayer` to get to the DetailedExamples struct
+        let start = Detailed3DExamples.randomBush
+
+        XCTAssertEqual(start.prng.seed, 42)
+        XCTAssertEqual(start.prng._invokeCount, 0)
+
+        let oneEv = start.evolve()
+        let downcastOneEv = oneEv as! LSystemRNG<PRNG>
+        XCTAssertEqual(downcastOneEv.prng.seed, 42)
+        XCTAssertEqual(downcastOneEv.prng._invokeCount, 2)
+        
+        start.prng.resetRNG(seed: start.prng.seed)
+        XCTAssertEqual(downcastOneEv.prng.seed, 42)
+        XCTAssertEqual(downcastOneEv.prng.position, 42)
+        XCTAssertEqual(downcastOneEv.prng._invokeCount, 0)
     }
 }

--- a/Tests/LindenmayerTests/PRNGWrapperTests.swift
+++ b/Tests/LindenmayerTests/PRNGWrapperTests.swift
@@ -81,7 +81,7 @@ final class PRNGWrapperTests: XCTestCase {
         XCTAssertEqual(downcastOneEv.prng._invokeCount, 4)
         start.prng.resetRNG(seed: start.prng.seed)
     }
-    
+
     func testResettingPRNG() throws {
         // requires `@testable import Lindenmayer` to get to the DetailedExamples struct
         let start = Detailed3DExamples.randomBush
@@ -93,7 +93,7 @@ final class PRNGWrapperTests: XCTestCase {
         let downcastOneEv = oneEv as! LSystemRNG<PRNG>
         XCTAssertEqual(downcastOneEv.prng.seed, 42)
         XCTAssertEqual(downcastOneEv.prng._invokeCount, 2)
-        
+
         start.prng.resetRNG(seed: start.prng.seed)
         XCTAssertEqual(downcastOneEv.prng.seed, 42)
         XCTAssertEqual(downcastOneEv.prng.position, 42)

--- a/Tests/LindenmayerTests/PWrapperTests.swift
+++ b/Tests/LindenmayerTests/PWrapperTests.swift
@@ -1,0 +1,49 @@
+//
+//  PWrapperTests.swift
+//  
+//
+//  Created by Joseph Heck on 1/4/22.
+//
+
+
+@testable import Lindenmayer
+import Squirrel3
+import XCTest
+
+final class PWrapperTests: XCTestCase {
+    func testInitalParameter() throws {
+        
+        struct P: Equatable {
+            let value: Int
+        }
+        let initialP = P(value: 10)
+                
+        let f = Lindenmayer.withDefines(Modules.Internode(), prng: PRNG(seed: 0), parameters:initialP)
+            .rewriteWithParams(directContext: Modules.Internode.self) { m, params in
+                XCTAssertEqual(params.value, 10)
+                return [m]
+            }
+        let next = f.evolve()
+        XCTAssertEqual(f.parameters.unwrap().value, 10)
+        XCTAssertNotNil(next)
+    }
+
+    func testUpdatedParameter() throws {
+        struct P: Equatable {
+            let value: Int
+        }
+        let initialP = P(value: 10)
+                
+        let f = Lindenmayer.withDefines(Modules.Internode(), prng: PRNG(seed: 0), parameters:initialP)
+            .rewriteWithParams(directContext: Modules.Internode.self) { m, params in
+                XCTAssertEqual(params.value, 13)
+                return [m]
+            }
+        XCTAssertEqual(f.parameters.unwrap().value, 10)
+        f.parameters.update(P(value: 13))
+        let next = f.evolve()
+        XCTAssertEqual(f.parameters.unwrap().value, 13)
+        XCTAssertNotNil(next)
+    }
+
+}

--- a/Tests/LindenmayerTests/PWrapperTests.swift
+++ b/Tests/LindenmayerTests/PWrapperTests.swift
@@ -43,13 +43,13 @@ final class PWrapperTests: XCTestCase {
         XCTAssertEqual(f.parameters.unwrap().value, 13)
         XCTAssertNotNil(next)
     }
-    
+
     func testCodabling() throws {
         let x = JSONEncoder()
         let zzz = try x.encode(Detailed3DExamples.figure2_6B)
         print(String(data: zzz, encoding: .utf8)!)
-/*
- {"contractionRatioForTrunk":0.9,"widthContraction":0.707,"lateralBranchAngle":45,"trunklength":10,"trunkdiameter":1,"branchAngle":45,"divergence":137.5,"contractionRatioForBranch":0.9}
- */
+        /*
+         {"contractionRatioForTrunk":0.9,"widthContraction":0.707,"lateralBranchAngle":45,"trunklength":10,"trunkdiameter":1,"branchAngle":45,"divergence":137.5,"contractionRatioForBranch":0.9}
+         */
     }
 }

--- a/Tests/LindenmayerTests/PWrapperTests.swift
+++ b/Tests/LindenmayerTests/PWrapperTests.swift
@@ -1,10 +1,9 @@
 //
 //  PWrapperTests.swift
-//  
+//
 //
 //  Created by Joseph Heck on 1/4/22.
 //
-
 
 @testable import Lindenmayer
 import Squirrel3
@@ -12,13 +11,12 @@ import XCTest
 
 final class PWrapperTests: XCTestCase {
     func testInitalParameter() throws {
-        
         struct P: Equatable {
             let value: Int
         }
         let initialP = P(value: 10)
-                
-        let f = Lindenmayer.withDefines(Modules.Internode(), prng: PRNG(seed: 0), parameters:initialP)
+
+        let f = Lindenmayer.withDefines(Modules.Internode(), prng: PRNG(seed: 0), parameters: initialP)
             .rewriteWithParams(directContext: Modules.Internode.self) { m, params in
                 XCTAssertEqual(params.value, 10)
                 return [m]
@@ -33,8 +31,8 @@ final class PWrapperTests: XCTestCase {
             let value: Int
         }
         let initialP = P(value: 10)
-                
-        let f = Lindenmayer.withDefines(Modules.Internode(), prng: PRNG(seed: 0), parameters:initialP)
+
+        let f = Lindenmayer.withDefines(Modules.Internode(), prng: PRNG(seed: 0), parameters: initialP)
             .rewriteWithParams(directContext: Modules.Internode.self) { m, params in
                 XCTAssertEqual(params.value, 13)
                 return [m]
@@ -45,5 +43,4 @@ final class PWrapperTests: XCTestCase {
         XCTAssertEqual(f.parameters.unwrap().value, 13)
         XCTAssertNotNil(next)
     }
-
 }

--- a/Tests/LindenmayerTests/PWrapperTests.swift
+++ b/Tests/LindenmayerTests/PWrapperTests.swift
@@ -43,4 +43,13 @@ final class PWrapperTests: XCTestCase {
         XCTAssertEqual(f.parameters.unwrap().value, 13)
         XCTAssertNotNil(next)
     }
+    
+    func testCodabling() throws {
+        let x = JSONEncoder()
+        let zzz = try x.encode(Detailed3DExamples.figure2_6B)
+        print(String(data: zzz, encoding: .utf8)!)
+/*
+ {"contractionRatioForTrunk":0.9,"widthContraction":0.707,"lateralBranchAngle":45,"trunklength":10,"trunkdiameter":1,"branchAngle":45,"divergence":137.5,"contractionRatioForBranch":0.9}
+ */
+    }
 }

--- a/Tests/LindenmayerTests/PerformanceTests.swift
+++ b/Tests/LindenmayerTests/PerformanceTests.swift
@@ -4,35 +4,27 @@ import XCTest
 final class PerformanceTests: XCTestCase {
     func X_testMemoryUse() {
         measure(metrics: [XCTMemoryMetric()]) {
-            do {
-                let tree = Examples2D.barnsleyFern.lsystem
-                let evo1 = try tree.evolve(iterations: 6)
-                XCTAssertNotNil(evo1)
-            } catch {}
+            let tree = Examples2D.barnsleyFern.lsystem
+            let evo1 = tree.evolved(iterations: 6)
+            XCTAssertNotNil(evo1)
         }
     }
 
     func X_testEvolutionSpeed() {
         measure {
-            do {
-                // 20.675 seconds
-                let tree = Examples2D.barnsleyFern.lsystem
-                let evo1 = try tree.evolve(iterations: 10)
-                XCTAssertNotNil(evo1)
-            } catch {}
+            // 20.675 seconds
+            let tree = Examples2D.barnsleyFern.lsystem
+            let evo1 = tree.evolved(iterations: 10)
+            XCTAssertNotNil(evo1)
         }
     }
 
     func X_testPerfBoundingRectCalc() {
         let evo1: LSystem?
-        do {
-            // 20.675 seconds
-            let tree = Examples2D.barnsleyFern.lsystem
-            evo1 = try tree.evolve(iterations: 10)
-            XCTAssertNotNil(evo1)
-        } catch {
-            evo1 = nil
-        }
+        // 20.675 seconds
+        let tree = Examples2D.barnsleyFern.lsystem
+        evo1 = tree.evolved(iterations: 10)
+        XCTAssertNotNil(evo1)
         measure {
             // 9.9 seconds
             let path: CGRect = GraphicsContextRenderer().calcBoundingRect(system: evo1!)

--- a/Tests/LindenmayerTests/WhiteboxLSystemTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxLSystemTests.swift
@@ -4,7 +4,7 @@ import XCTest
 
 final class WhiteboxLSystemTests: XCTestCase {
     func testLSystemDefault() throws {
-        let x = LSystemRNG<PRNG>(axiom: [Modules.Internode()], prng: RNGWrapper(PRNG(seed: 0)))
+        let x = LSystemRNG<PRNG>(axiom: [Modules.Internode()], state: nil, prng: RNGWrapper(PRNG(seed: 0)))
         XCTAssertNotNil(x)
         // Verify internal state of LSystem:
         // No rules

--- a/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
@@ -20,7 +20,7 @@ final class WhiteboxParametricRuleTests: XCTestCase {
     let p = ParameterizedExample()
 
     func testRuleDefaults() throws {
-        let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self, parameters: ExampleDefines(), prng: RNGWrapper(PRNG(seed: 0)), where: nil) { _, p, _ -> [Module] in
+        let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self, parameters: PWrapper(ExampleDefines()), prng: RNGWrapper(PRNG(seed: 0)), where: nil) { _, p, _ -> [Module] in
             [ParameterizedExample(p.value + 1.0)]
         }
 
@@ -44,7 +44,7 @@ final class WhiteboxParametricRuleTests: XCTestCase {
 
     func testRuleDefaultsWithSystemParameters() throws {
         let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self,
-                                            parameters: ExampleDefines(),
+                                            parameters: PWrapper(ExampleDefines()),
                                             prng: RNGWrapper(PRNG(seed: 0)),
                                             where: nil) { _, p, _ -> [Module] in
             [ParameterizedExample(p.value + p.value)]


### PR DESCRIPTION
resolves #4 

- removed try/catch & throws structures around the LSystem protocol, since it no longer needs it
- renamed evolve(Int) to evolved(Int)