### PR TITLE
Roll to vertical

### DIFF
--- a/Sources/Lindenmayer/BuiltinModules.swift
+++ b/Sources/Lindenmayer/BuiltinModules.swift
@@ -1,6 +1,6 @@
 //
 //  BuiltinModules.swift
-//  X5336
+//
 //
 //  Created by Joseph Heck on 12/12/21.
 //
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI // for the 'Angle' type
 
-/// A collection of built-in modules for use in LSystems
+/// A namespace for a collection of built-in modules for use in L-systems.
 public enum Modules {}
 
 public extension Modules {
@@ -23,6 +23,7 @@ public extension Modules {
 
     // MARK: - Built-in Modules that are effectively wrappers around specific rendering commands
 
+    /// A module that informs a renderer to turn left while rendering the L-system.
     struct TurnLeft: Module {
         public let name = RenderCommand.turnLeft.name
         public let angle: Angle
@@ -39,6 +40,7 @@ public extension Modules {
         }
     }
 
+    /// A module that informs a renderer to turn right while rendering the L-system.
     struct TurnRight: Module {
         public let name = RenderCommand.turnRight.name
         public let angle: Angle
@@ -55,6 +57,7 @@ public extension Modules {
         }
     }
 
+    /// A module that informs a renderer to draw a line along the current heading while rendering the L-system.
     struct Draw: Module {
         public let name = RenderCommand.draw.name
         public let length: Double
@@ -71,6 +74,7 @@ public extension Modules {
         }
     }
 
+    /// A module that informs a renderer to move forward along the current heading without other representation while rendering the L-system.
     struct Move: Module {
         public let name = RenderCommand.move.name
         public let length: Double
@@ -87,6 +91,7 @@ public extension Modules {
         }
     }
 
+    /// A module that informs a renderer that the L-system representation should branch.
     struct Branch: Module {
         public let name = RenderCommand.branch.name
         public var render2D: [TwoDRenderCmd] {
@@ -100,6 +105,7 @@ public extension Modules {
         public init() {}
     }
 
+    /// A module that informs a renderer that the branch of the L-system branch representation is complete.
     struct EndBranch: Module {
         public let name = RenderCommand.endBranch.name
 
@@ -114,6 +120,7 @@ public extension Modules {
         public init() {}
     }
 
+    /// A module that informs a renderer to change the heading by rolling around the current axis to the left.
     struct RollLeft: Module {
         public let name = RenderCommand.rollLeft.name
         public let angle: Angle
@@ -130,6 +137,7 @@ public extension Modules {
         }
     }
 
+    /// A module that informs a renderer to change the heading by rolling around the current axis to the right.
     struct RollRight: Module {
         public let name = RenderCommand.rollRight.name
         public let angle: Angle
@@ -146,6 +154,7 @@ public extension Modules {
         }
     }
 
+    /// A module that informs a renderer to change the heading by pitching up.
     struct PitchUp: Module {
         public let name = RenderCommand.pitchUp.name
         public let angle: Angle
@@ -162,6 +171,7 @@ public extension Modules {
         }
     }
 
+    /// A module that informs a renderer to change the heading by pitching down.
     struct PitchDown: Module {
         public let name = RenderCommand.pitchDown.name
         public let angle: Angle
@@ -178,14 +188,15 @@ public extension Modules {
         }
     }
 
-    struct LevelOut: Module {
-        public let name = RenderCommand.rollToHorizontal.name
+    /// A module that informs the renderer to roll around its current heading so that the upward vector is as vertical as possible.
+    struct RollUpToVertical: Module {
+        public let name = RenderCommand.rollUpToVertical.name
         public var render2D: [TwoDRenderCmd] {
             []
         }
 
         public var render3D: ThreeDRenderCmd {
-            RenderCommand.rollToHorizontal
+            RenderCommand.rollUpToVertical
         }
 
         public init() {}

--- a/Sources/Lindenmayer/BuiltinModules.swift
+++ b/Sources/Lindenmayer/BuiltinModules.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI // for the 'Angle' type
 
 /// A collection of built-in modules for use in LSystems
 public enum Modules {}
@@ -24,7 +25,7 @@ public extension Modules {
 
     struct TurnLeft: Module {
         public let name = RenderCommand.turnLeft.name
-        public let angle: Double
+        public let angle: Angle
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.TurnLeft(angle: angle)]
         }
@@ -33,14 +34,14 @@ public extension Modules {
             RenderCommand.TurnLeft(angle: angle)
         }
 
-        public init(angle: Double = 90) {
+        public init(angle: Angle = Angle.degrees(90)) {
             self.angle = angle
         }
     }
 
     struct TurnRight: Module {
         public let name = RenderCommand.turnRight.name
-        public let angle: Double
+        public let angle: Angle
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.TurnRight(angle: angle)]
         }
@@ -49,7 +50,7 @@ public extension Modules {
             RenderCommand.TurnRight(angle: angle)
         }
 
-        public init(angle: Double = 90) {
+        public init(angle: Angle = .degrees(90)) {
             self.angle = angle
         }
     }
@@ -115,7 +116,7 @@ public extension Modules {
 
     struct RollLeft: Module {
         public let name = RenderCommand.rollLeft.name
-        public let angle: Double
+        public let angle: Angle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -124,14 +125,14 @@ public extension Modules {
             RenderCommand.RollLeft(angle: angle)
         }
 
-        public init(angle: Double = 90) {
+        public init(angle: Angle = .degrees(90)) {
             self.angle = angle
         }
     }
 
     struct RollRight: Module {
         public let name = RenderCommand.rollRight.name
-        public let angle: Double
+        public let angle: Angle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -140,14 +141,14 @@ public extension Modules {
             RenderCommand.RollRight(angle: angle)
         }
 
-        public init(angle: Double = 90) {
+        public init(angle: Angle = .degrees(90)) {
             self.angle = angle
         }
     }
 
     struct PitchUp: Module {
         public let name = RenderCommand.pitchUp.name
-        public let angle: Double
+        public let angle: Angle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -156,14 +157,14 @@ public extension Modules {
             RenderCommand.PitchUp(angle: angle)
         }
 
-        public init(angle: Double = 90) {
+        public init(angle: Angle = .degrees(30)) {
             self.angle = angle
         }
     }
 
     struct PitchDown: Module {
         public let name = RenderCommand.pitchDown.name
-        public let angle: Double
+        public let angle: Angle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -171,16 +172,20 @@ public extension Modules {
         public var render3D: ThreeDRenderCmd {
             RenderCommand.PitchDown(angle: angle)
         }
+
+        public init(angle: Angle = .degrees(30)) {
+            self.angle = angle
+        }
     }
 
     struct LevelOut: Module {
-        public let name = RenderCommand.spinToFlat.name
+        public let name = RenderCommand.rollToHorizontal.name
         public var render2D: [TwoDRenderCmd] {
             []
         }
 
         public var render3D: ThreeDRenderCmd {
-            RenderCommand.SpinToFlat()
+            RenderCommand.rollToHorizontal
         }
 
         public init() {}

--- a/Sources/Lindenmayer/DebugModule.swift
+++ b/Sources/Lindenmayer/DebugModule.swift
@@ -26,7 +26,7 @@ public class DebugModule: Identifiable {
     public var mirroredProperties: [String] {
         _filteredAndSortedKeys
     }
-    
+
     /// Returns the value of the property you identify from the wrapped Module  as a String.
     /// - Parameter propertyKey: The property to return.
     /// - Returns: A string that represents the property, or `nil` if that property doesn't exist.
@@ -45,7 +45,7 @@ public class DebugModule: Identifiable {
         }
         return nil
     }
-    
+
     /// Creates a new debug module.
     /// - Parameters:
     ///   - m: The module to use to initialize the debug module.

--- a/Sources/Lindenmayer/DebugModule.swift
+++ b/Sources/Lindenmayer/DebugModule.swift
@@ -7,15 +7,29 @@
 
 import Foundation
 
+/// A class that wraps an abstract Module and provides access to its internal state as formatted strings.
+///
+/// The class provides an `Identifiable` reference based on the location within an existing ``LSystem``.
+/// The internal state of the underlying ``Module`` instance is exposed using `Mirror`.
 public class DebugModule: Identifiable {
+    /// The abstract, underlying module instance with which you initialized the wrapper.
     public let module: Module
+    /// A Boolean value that indicates whether the module was newly added in the last evolution of the L-System.
     public let new: Bool
+    /// The location of the module within an L-system's state.
+    ///
+    /// Don't use this value to identify modules from multiple L-systems.
+    /// The identifiable capabilities are only valid for a single L-system.
     public let id: Int
     private let _filteredAndSortedKeys: [String]
+    /// An array that contains the string values for each of the properties within the wrapped module.
     public var mirroredProperties: [String] {
         _filteredAndSortedKeys
     }
-
+    
+    /// Returns the value of the property you identify from the wrapped Module  as a String.
+    /// - Parameter propertyKey: The property to return.
+    /// - Returns: A string that represents the property, or `nil` if that property doesn't exist.
     public func valueOf(_ propertyKey: String) -> String? {
         if module.children().keys.contains(propertyKey) {
             if let value = module.children()[propertyKey] {
@@ -31,7 +45,12 @@ public class DebugModule: Identifiable {
         }
         return nil
     }
-
+    
+    /// Creates a new debug module.
+    /// - Parameters:
+    ///   - m: The module to use to initialize the debug module.
+    ///   - at: The location within the state of an L-system.
+    ///   - isNew: A Boolean value that indicates the module was created in the last evolution.
     init(_ m: Module, at: Int, isNew: Bool = false) {
         id = at
         module = m
@@ -43,12 +62,21 @@ public class DebugModule: Identifiable {
 }
 
 extension DebugModule: Equatable {
+    /// Compares two debug modules based on their location within an L-system and their name.
+    /// - Returns: A Boolean value that indicates whether the two values are equal.
+    ///
+    /// Do not use this method to compare two debug modules from different L-systems.
     public static func == (lhs: DebugModule, rhs: DebugModule) -> Bool {
         lhs.id == rhs.id && lhs.module.name == rhs.module.name
     }
 }
 
 public extension LSystem {
+    /// Returns a debug module wrapping the module at the state position you provide.
+    /// - Parameter at: The location of the state within the L-systems state array.
+    /// - Returns: A ``DebugModule`` initialized with the state at the location you provide.
+    ///
+    /// This method crashes (using `precondition`) if you attempt to access state outside the bounds of the L-system's state array.
     func state(at: Int) -> DebugModule {
         precondition(at >= 0 && at < state.count && at < newStateIndicators.count)
         return DebugModule(state[at], at: at, isNew: newStateIndicators[at])

--- a/Sources/Lindenmayer/Examples2D.swift
+++ b/Sources/Lindenmayer/Examples2D.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import SwiftUI // for `Angle`
 
 /// A collection of two-dimensional example L-systems.
 ///
@@ -82,8 +83,8 @@ public enum Detailed2DExamples {
     static var fractalTree = Lindenmayer.basic(leaf)
         .rewrite(Leaf.self) { leaf in
             [stem,
-             Modules.Branch(), Modules.TurnLeft(angle: 45), leaf, Modules.EndBranch(),
-             Modules.TurnRight(angle: 45), leaf]
+             Modules.Branch(), Modules.TurnLeft(angle: Angle(degrees:45)), leaf, Modules.EndBranch(),
+             Modules.TurnRight(angle: Angle(degrees:45)), leaf]
         }
         .rewrite(Stem.self) { stem in
             [stem, stem]
@@ -93,10 +94,10 @@ public enum Detailed2DExamples {
 
     static var kochCurve = Lindenmayer.basic(Modules.Draw(length: 10))
         .rewrite(Modules.Draw.self) { _ in
-            [Modules.Draw(length: 10), Modules.TurnLeft(angle: 90),
-             Modules.Draw(length: 10), Modules.TurnRight(angle: 90),
-             Modules.Draw(length: 10), Modules.TurnRight(angle: 90),
-             Modules.Draw(length: 10), Modules.TurnLeft(angle: 90),
+            [Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees:90)),
+             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees:90)),
+             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees:90)),
+             Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees:90)),
              Modules.Draw(length: 10)]
         }
 
@@ -117,15 +118,15 @@ public enum Detailed2DExamples {
     static var g = G()
 
     static var sierpinskiTriangle = Lindenmayer.basic(
-        [f, Modules.TurnRight(angle: 120),
-         g, Modules.TurnRight(angle: 120),
-         g, Modules.TurnRight(angle: 120)]
+        [f, Modules.TurnRight(angle: Angle(degrees:120)),
+         g, Modules.TurnRight(angle: Angle(degrees:120)),
+         g, Modules.TurnRight(angle: Angle(degrees:120))]
     )
     .rewrite(F.self) { _ in
-        [f, Modules.TurnRight(angle: 120),
-         g, Modules.TurnLeft(angle: 120),
-         f, Modules.TurnLeft(angle: 120),
-         g, Modules.TurnRight(angle: 120),
+        [f, Modules.TurnRight(angle: Angle(degrees:120)),
+         g, Modules.TurnLeft(angle: Angle(degrees:120)),
+         f, Modules.TurnLeft(angle: Angle(degrees:120)),
+         g, Modules.TurnRight(angle: Angle(degrees:120)),
          f]
     }
     .rewrite(G.self) { _ in
@@ -136,10 +137,10 @@ public enum Detailed2DExamples {
 
     static var dragonCurve = Lindenmayer.basic(f)
         .rewrite(F.self) { _ in
-            [f, Modules.TurnLeft(angle: 90), g]
+            [f, Modules.TurnLeft(angle: Angle(degrees:90)), g]
         }
         .rewrite(G.self) { _ in
-            [f, Modules.TurnRight(angle: 90), g]
+            [f, Modules.TurnRight(angle: Angle(degrees:90)), g]
         }
 
     // - MARK: Barnsley fern example
@@ -152,14 +153,14 @@ public enum Detailed2DExamples {
 
     static var barnsleyFern = Lindenmayer.basic(x)
         .rewrite(X.self) { _ in
-            [f, Modules.TurnLeft(angle: 25),
+            [f, Modules.TurnLeft(angle: Angle(degrees:25)),
              Modules.Branch(),
              Modules.Branch(), x, Modules.EndBranch(),
-             Modules.TurnRight(angle: 25), x,
+             Modules.TurnRight(angle: Angle(degrees:25)), x,
              Modules.EndBranch(),
-             Modules.TurnRight(angle: 25), f,
-             Modules.Branch(), Modules.TurnRight(angle: 25), f, x, Modules.EndBranch(),
-             Modules.TurnLeft(angle: 25), x]
+             Modules.TurnRight(angle: Angle(degrees:25)), f,
+             Modules.Branch(), Modules.TurnRight(angle: Angle(degrees:25)), f, x, Modules.EndBranch(),
+             Modules.TurnLeft(angle: Angle(degrees:25)), x]
         }
         .rewrite(F.self) { _ in
             [f, f]

--- a/Sources/Lindenmayer/Examples2D.swift
+++ b/Sources/Lindenmayer/Examples2D.swift
@@ -83,8 +83,8 @@ public enum Detailed2DExamples {
     static var fractalTree = Lindenmayer.basic(leaf)
         .rewrite(Leaf.self) { leaf in
             [stem,
-             Modules.Branch(), Modules.TurnLeft(angle: Angle(degrees:45)), leaf, Modules.EndBranch(),
-             Modules.TurnRight(angle: Angle(degrees:45)), leaf]
+             Modules.Branch(), Modules.TurnLeft(angle: Angle(degrees: 45)), leaf, Modules.EndBranch(),
+             Modules.TurnRight(angle: Angle(degrees: 45)), leaf]
         }
         .rewrite(Stem.self) { stem in
             [stem, stem]
@@ -94,10 +94,10 @@ public enum Detailed2DExamples {
 
     static var kochCurve = Lindenmayer.basic(Modules.Draw(length: 10))
         .rewrite(Modules.Draw.self) { _ in
-            [Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees:90)),
-             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees:90)),
-             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees:90)),
-             Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees:90)),
+            [Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees: 90)),
+             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees: 90)),
+             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees: 90)),
+             Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees: 90)),
              Modules.Draw(length: 10)]
         }
 
@@ -118,15 +118,15 @@ public enum Detailed2DExamples {
     static var g = G()
 
     static var sierpinskiTriangle = Lindenmayer.basic(
-        [f, Modules.TurnRight(angle: Angle(degrees:120)),
-         g, Modules.TurnRight(angle: Angle(degrees:120)),
-         g, Modules.TurnRight(angle: Angle(degrees:120))]
+        [f, Modules.TurnRight(angle: Angle(degrees: 120)),
+         g, Modules.TurnRight(angle: Angle(degrees: 120)),
+         g, Modules.TurnRight(angle: Angle(degrees: 120))]
     )
     .rewrite(F.self) { _ in
-        [f, Modules.TurnRight(angle: Angle(degrees:120)),
-         g, Modules.TurnLeft(angle: Angle(degrees:120)),
-         f, Modules.TurnLeft(angle: Angle(degrees:120)),
-         g, Modules.TurnRight(angle: Angle(degrees:120)),
+        [f, Modules.TurnRight(angle: Angle(degrees: 120)),
+         g, Modules.TurnLeft(angle: Angle(degrees: 120)),
+         f, Modules.TurnLeft(angle: Angle(degrees: 120)),
+         g, Modules.TurnRight(angle: Angle(degrees: 120)),
          f]
     }
     .rewrite(G.self) { _ in
@@ -137,10 +137,10 @@ public enum Detailed2DExamples {
 
     static var dragonCurve = Lindenmayer.basic(f)
         .rewrite(F.self) { _ in
-            [f, Modules.TurnLeft(angle: Angle(degrees:90)), g]
+            [f, Modules.TurnLeft(angle: Angle(degrees: 90)), g]
         }
         .rewrite(G.self) { _ in
-            [f, Modules.TurnRight(angle: Angle(degrees:90)), g]
+            [f, Modules.TurnRight(angle: Angle(degrees: 90)), g]
         }
 
     // - MARK: Barnsley fern example
@@ -153,14 +153,14 @@ public enum Detailed2DExamples {
 
     static var barnsleyFern = Lindenmayer.basic(x)
         .rewrite(X.self) { _ in
-            [f, Modules.TurnLeft(angle: Angle(degrees:25)),
+            [f, Modules.TurnLeft(angle: Angle(degrees: 25)),
              Modules.Branch(),
              Modules.Branch(), x, Modules.EndBranch(),
-             Modules.TurnRight(angle: Angle(degrees:25)), x,
+             Modules.TurnRight(angle: Angle(degrees: 25)), x,
              Modules.EndBranch(),
-             Modules.TurnRight(angle: Angle(degrees:25)), f,
-             Modules.Branch(), Modules.TurnRight(angle: Angle(degrees:25)), f, x, Modules.EndBranch(),
-             Modules.TurnLeft(angle: Angle(degrees:25)), x]
+             Modules.TurnRight(angle: Angle(degrees: 25)), f,
+             Modules.Branch(), Modules.TurnRight(angle: Angle(degrees: 25)), f, x, Modules.EndBranch(),
+             Modules.TurnLeft(angle: Angle(degrees: 25)), x]
         }
         .rewrite(F.self) { _ in
             [f, f]

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI // for `Angle`
 import Squirrel3
 
 /// A collection of three-dimensional example L-systems.
@@ -192,11 +193,11 @@ public enum Detailed3DExamples {
         [
             StaticTrunk(growthDistance: trunk.growthDistance, diameter: trunk.diameter),
             Modules.Branch(),
-            Modules.PitchDown(angle: params.branchAngle),
+            Modules.PitchDown(angle: Angle(degrees: params.branchAngle)),
             MainBranch(growthDistance: trunk.growthDistance * params.contractionRatioForBranch,
                        diameter: trunk.diameter * params.widthContraction),
             Modules.EndBranch(),
-            Modules.RollLeft(angle: params.divergence),
+            Modules.RollLeft(angle: Angle(degrees: params.divergence)),
             Trunk(growthDistance: trunk.growthDistance * params.contractionRatioForTrunk,
                   diameter: trunk.diameter * params.widthContraction),
         ]
@@ -208,7 +209,7 @@ public enum Detailed3DExamples {
             StaticTrunk(growthDistance: branch.growthDistance, diameter: branch.diameter),
             Modules.Branch(),
 
-            Modules.TurnLeft(angle: params.lateralBranchAngle),
+            Modules.TurnLeft(angle: Angle(degrees: params.lateralBranchAngle)),
             Modules.LevelOut(),
             SecondaryBranch(growthDistance: branch.growthDistance * params.contractionRatioForBranch,
                             diameter: branch.diameter * params.widthContraction),
@@ -225,7 +226,7 @@ public enum Detailed3DExamples {
             StaticTrunk(growthDistance: branch.growthDistance, diameter: branch.diameter),
             Modules.Branch(),
 
-            Modules.TurnRight(angle: params.branchAngle),
+            Modules.TurnRight(angle: Angle(degrees: params.branchAngle)),
             Modules.LevelOut(),
 
             MainBranch(growthDistance: branch.growthDistance * params.contractionRatioForBranch,
@@ -285,14 +286,14 @@ public enum Detailed3DExamples {
             StaticTrunk(growthDistance: node.growthDistance, diameter: node.diameter),
 
             Modules.Branch(),
-            Modules.PitchDown(angle: params.a1),
+            Modules.PitchDown(angle: Angle(degrees: params.a1)),
             SecondaryBranch(growthDistance: node.growthDistance * params.r1, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
 
-            Modules.RollLeft(angle: 180),
+            Modules.RollLeft(angle: Angle(degrees: 180)),
 
             Modules.Branch(),
-            Modules.PitchDown(angle: params.a2),
+            Modules.PitchDown(angle: Angle(degrees: params.a2)),
             SecondaryBranch(growthDistance: node.growthDistance * params.r2, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
         ]
@@ -302,12 +303,12 @@ public enum Detailed3DExamples {
         [
             StaticTrunk(growthDistance: node.growthDistance, diameter: node.diameter),
             Modules.Branch(),
-            Modules.TurnRight(angle: params.a1),
+            Modules.TurnRight(angle: Angle(degrees: params.a1)),
             Modules.LevelOut(),
             SecondaryBranch(growthDistance: node.growthDistance * params.r1, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
             Modules.Branch(),
-            Modules.TurnLeft(angle: params.a2),
+            Modules.TurnLeft(angle: Angle(degrees: params.a2)),
             Modules.LevelOut(),
             SecondaryBranch(growthDistance: node.growthDistance * params.r2, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
@@ -349,13 +350,13 @@ public enum Detailed3DExamples {
             if rng.p(0.5) {
                 return [
                     StaticStem2(length: 2),
-                    Modules.PitchDown(angle: Double(rng.randomFloat(in: lower ... upper))),
+                    Modules.PitchDown(angle: Angle(degrees: Double(rng.randomFloat(in: lower ... upper)))),
                     Stem2(length: stem.length),
                 ]
             } else {
                 return [
                     StaticStem2(length: 2),
-                    Modules.PitchUp(angle: Double(rng.randomFloat(in: lower ... upper))),
+                    Modules.PitchUp(angle: Angle(degrees: Double(rng.randomFloat(in: lower ... upper)))),
                     Stem2(length: stem.length),
                 ]
             }

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import SwiftUI // for `Angle`
 import Squirrel3
+import SwiftUI // for `Angle`
 
 /// A collection of three-dimensional example L-systems.
 public enum Examples3D: String, CaseIterable, Identifiable {
@@ -210,7 +210,7 @@ public enum Detailed3DExamples {
             Modules.Branch(),
 
             Modules.TurnLeft(angle: Angle(degrees: params.lateralBranchAngle)),
-            Modules.LevelOut(),
+            Modules.RollUpToVertical(),
             SecondaryBranch(growthDistance: branch.growthDistance * params.contractionRatioForBranch,
                             diameter: branch.diameter * params.widthContraction),
 
@@ -227,7 +227,7 @@ public enum Detailed3DExamples {
             Modules.Branch(),
 
             Modules.TurnRight(angle: Angle(degrees: params.branchAngle)),
-            Modules.LevelOut(),
+            Modules.RollUpToVertical(),
 
             MainBranch(growthDistance: branch.growthDistance * params.contractionRatioForBranch,
                        diameter: branch.diameter * params.widthContraction),
@@ -304,12 +304,12 @@ public enum Detailed3DExamples {
             StaticTrunk(growthDistance: node.growthDistance, diameter: node.diameter),
             Modules.Branch(),
             Modules.TurnRight(angle: Angle(degrees: params.a1)),
-            Modules.LevelOut(),
+            Modules.RollUpToVertical(),
             SecondaryBranch(growthDistance: node.growthDistance * params.r1, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
             Modules.Branch(),
             Modules.TurnLeft(angle: Angle(degrees: params.a2)),
-            Modules.LevelOut(),
+            Modules.RollUpToVertical(),
             SecondaryBranch(growthDistance: node.growthDistance * params.r2, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
         ]

--- a/Sources/Lindenmayer/GraphicsContextRenderer.swift
+++ b/Sources/Lindenmayer/GraphicsContextRenderer.swift
@@ -6,19 +6,19 @@
 //
 
 import CoreGraphics
-import SwiftUI
+import SwiftUI // for `Angle`
 
 struct PathState {
-    var angle: Double
+    var angle: Angle
     var position: CGPoint
     var lineWidth: Double
     var lineColor: ColorRepresentation
 
     init() {
-        self.init(-90, .zero, 1.0, ColorRepresentation.black)
+        self.init(Angle(degrees: -90), .zero, 1.0, ColorRepresentation.black)
     }
 
-    init(_ angle: Double, _ position: CGPoint, _ lineWidth: Double, _ lineColor: ColorRepresentation) {
+    init(_ angle: Angle, _ position: CGPoint, _ lineWidth: Double, _ lineColor: ColorRepresentation) {
         self.angle = angle
         self.position = position
         self.lineWidth = lineWidth
@@ -238,13 +238,9 @@ public struct GraphicsContextRenderer {
 
     // MARK: - Private
 
-    func degreesToRadians(_ value: Double) -> Double {
-        return value * .pi / 180.0
-    }
-
     func updatedStateByMoving(_ state: PathState, distance: Double) -> PathState {
-        let x = state.position.x + CGFloat(distance * cos(degreesToRadians(state.angle)))
-        let y = state.position.y + CGFloat(distance * sin(degreesToRadians(state.angle)))
+        let x = state.position.x + CGFloat(distance * cos(state.angle.radians))
+        let y = state.position.y + CGFloat(distance * sin(state.angle.radians))
 
         return PathState(state.angle, CGPoint(x: x, y: y), state.lineWidth, state.lineColor)
     }
@@ -257,7 +253,7 @@ public struct GraphicsContextRenderer {
         return PathState(state.angle, state.position, state.lineWidth, lineColor)
     }
 
-    func updatedStateByTurning(_ state: PathState, angle: Double, direction: TurnDirection)
+    func updatedStateByTurning(_ state: PathState, angle: Angle, direction: TurnDirection)
         -> PathState
     {
         if direction == .left {

--- a/Sources/Lindenmayer/GraphicsContextRenderer.swift
+++ b/Sources/Lindenmayer/GraphicsContextRenderer.swift
@@ -1,6 +1,6 @@
 //
 //  GraphicsContextRenderer.swift
-//  X5336
+//
 //
 //  Created by Joseph Heck on 12/12/21.
 //
@@ -42,7 +42,7 @@ public struct GraphicsContextRenderer {
         case left
         case right
     }
-    
+
     /// Creates a new graphics context renderer with a base length of 1.
     /// - Parameter unitLength: A value that scales move and draw rendering commands.
     public init(unitLength: Double = 1) {

--- a/Sources/Lindenmayer/GraphicsContextRenderer.swift
+++ b/Sources/Lindenmayer/GraphicsContextRenderer.swift
@@ -28,11 +28,13 @@ struct PathState {
 
 // convenience for making a SwiftUI Color from the Color Representation struct
 extension ColorRepresentation {
+    /// The SwiftUI color from the color representation.
     var color: SwiftUI.Color {
         Color(red: red, green: green, blue: blue, opacity: alpha)
     }
 }
 
+/// A renderer that generates a 2D graphical representation of an L-system.
 public struct GraphicsContextRenderer {
     let unitLength: Double
 
@@ -40,12 +42,14 @@ public struct GraphicsContextRenderer {
         case left
         case right
     }
-
+    
+    /// Creates a new graphics context renderer with a base length of 1.
+    /// - Parameter unitLength: A value that scales move and draw rendering commands.
     public init(unitLength: Double = 1) {
         self.unitLength = unitLength
     }
 
-    /// Draws the L-System into the provided GraphicsContext.
+    /// Draws the L-System into the SwiftUI graphics context you provide.
     ///
     /// - Parameters:
     ///   - lsystem: The L-System to draw.

--- a/Sources/Lindenmayer/LSystemBasic.swift
+++ b/Sources/Lindenmayer/LSystemBasic.swift
@@ -8,6 +8,13 @@
 import Foundation
 
 /// A basic Lindenmayer system.
+///
+/// The basic Lindenmayer system doesn't use external parameters or a seed-able random number generator within its rules.
+/// If you want to create an L-system that uses a seed-able random number generator, use ``LSystemRNG``.
+/// If you want to create an L-system that uses a set of external parameters and a seed-able random number generator, use ``LSystemDefinesRNG``.
+///
+/// For more information on the background of Lindenmayer systems, see [Wikipedia's L-System](https://en.wikipedia.org/wiki/L-system).
+
 public struct LSystemBasic: LSystem {
     let axiom: [Module]
     /// The sequence of modules that represents the current state of the L-system.

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -19,7 +19,7 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNu
     public var newStateIndicators: [Bool]
 
     /// The parameters to provide to rules for evaluation and production.
-    public var parameters: PWrapper<PType>
+    public var parameters: ParametersWrapper<PType>
     let initialParameters: PType
 
     let prng: RNGWrapper<PRNG>
@@ -36,7 +36,7 @@ public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNu
     public init(axiom: [Module],
                 state: [Module]?,
                 newStateIndicators: [Bool]?,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 rules: [Rule] = [])
     {

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -1,6 +1,6 @@
 //
 //  ParametericLSystem.swift
-//  X5336
+//
 //
 //  Created by Joseph Heck on 12/12/21.
 //

--- a/Sources/Lindenmayer/LSystemDefinesRNG.swift
+++ b/Sources/Lindenmayer/LSystemDefinesRNG.swift
@@ -10,6 +10,10 @@ import Squirrel3
 
 /// A parameterized, stochastic Lindenmayer system.
 ///
+/// A parameterized, stochastic Lindenmayer system uses both external parameters and a seed-able random number generator, exposing both to the rules you create.
+/// If you want to create an L-system doesn't use parameters or a seed-able random number generator, use ``LSystemBasic``.
+/// If you want to create an L-system that doesn't use a set of external parameters, but does include a seed-able random number generator, use ``LSystemRNG``.
+///
 /// For more information on the background of Lindenmayer systems, see [Wikipedia's L-System](https://en.wikipedia.org/wiki/L-system).
 public struct LSystemDefinesRNG<PType, PRNG>: LSystem where PRNG: SeededRandomNumberGenerator {
     let axiom: [Module]

--- a/Sources/Lindenmayer/LSystemRNG.swift
+++ b/Sources/Lindenmayer/LSystemRNG.swift
@@ -10,6 +10,10 @@ import Squirrel3
 
 /// A stochastic Lindenmayer system.
 ///
+/// A stochastic Lindenmayer system uses a seed-able random number generator and exposes it to the rules you create, but doesn't use external parameters.
+/// If you want to create an L-system doesn't use uses a seed-able random number generator, use ``LSystemBasic``.
+/// If you want to create an L-system that uses a set of external parameters and a seed-able random number generator, use ``LSystemDefinesRNG``.
+///
 /// For more information on the background of Lindenmayer systems, see [Wikipedia's L-System](https://en.wikipedia.org/wiki/L-system).
 public struct LSystemRNG<PRNG>: LSystem where PRNG: SeededRandomNumberGenerator {
     let axiom: [Module]

--- a/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
+++ b/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
@@ -9,7 +9,7 @@ The library provides types and APIs enable you to create L-systems with rules an
 
 The 2D renderer uses [Canvas](http://developer.apple.com/documentation/swiftui/Canvas) and [GraphicsContext](https://developer.apple.com/documentation/swiftui/graphicscontext) from [SwiftUI](https://developer.apple.com/documentation/swiftui) on Apple platforms.
 The 3D renderer uses [SceneKit](https://developer.apple.com/documentation/scenekit) on Apple platforms.
-The related package ``LindenmayerViews`` provides SwiftUI views that present the results of the renderers.
+The related package `LindenmayerViews` provides SwiftUI views that present the results of the renderers.
 
 The API provides support for both context free and context sensitive L-system grammars, as well as parametric grammars.
 

--- a/Sources/Lindenmayer/Lindenmayer.swift
+++ b/Sources/Lindenmayer/Lindenmayer.swift
@@ -7,18 +7,19 @@
 
 import Foundation
 
+/// A type that provides convenient initializers for L-systems.
 public enum Lindenmayer {
     /// Creates a new Lindenmayer system from an initial state.
     /// - Parameters:
     ///   - axiom: An initial module that represents the initial state of the Lindenmayer system..
-    static func basic(_ axiom: Module) -> LSystemBasic {
+    public static func basic(_ axiom: Module) -> LSystemBasic {
         return LSystemBasic([axiom], state: nil, newStateIndicators: nil)
     }
 
     /// Creates a new Lindenmayer system from an initial state.
     /// - Parameters:
     ///   - axiom: A sequence of modules that represents the initial state of the Lindenmayer system..
-    static func basic(_ axiom: [Module]) -> LSystemBasic {
+    public static func basic(_ axiom: [Module]) -> LSystemBasic {
         return LSystemBasic(axiom, state: nil, newStateIndicators: nil)
     }
 
@@ -26,7 +27,7 @@ public enum Lindenmayer {
     /// - Parameters:
     ///   - axiom: An initial module that represents the initial state of the Lindenmayer system..
     ///   - prng: A psuedo-random number generator to use for randomness in rule productions.
-    static func withRNG<RNGType>(_ axiom: Module, prng: RNGType) -> LSystemRNG<RNGType> {
+    public static func withRNG<RNGType>(_ axiom: Module, prng: RNGType) -> LSystemRNG<RNGType> {
         return LSystemRNG(axiom: [axiom], state: nil, newStateIndicators: nil, prng: RNGWrapper(prng))
     }
 
@@ -34,7 +35,7 @@ public enum Lindenmayer {
     /// - Parameters:
     ///   - axiom: A sequence of modules that represents the initial state of the Lindenmayer system..
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
-    static func withRNG<RNGType>(_ axiom: [Module], prng: RNGType) -> LSystemRNG<RNGType> {
+    public static func withRNG<RNGType>(_ axiom: [Module], prng: RNGType) -> LSystemRNG<RNGType> {
         return LSystemRNG(axiom: axiom, state: nil, newStateIndicators: nil, prng: RNGWrapper(prng))
     }
 
@@ -43,7 +44,7 @@ public enum Lindenmayer {
     ///   - axiom: An initial module that represents the initial state of the Lindenmayer system.
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
-    static func withDefines<PType, RNGType>(_ axiom: Module, prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
+    public static func withDefines<PType, RNGType>(_ axiom: Module, prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
         return LSystemDefinesRNG(axiom: [axiom], state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(prng), rules: [])
     }
 
@@ -52,7 +53,7 @@ public enum Lindenmayer {
     ///   - axiom: A sequence of modules that represents the initial state of the Lindenmayer system..
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
-    static func withDefines<PType, RNGType>(_ axiom: [Module], prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
+    public static func withDefines<PType, RNGType>(_ axiom: [Module], prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
         return LSystemDefinesRNG(axiom: axiom, state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(prng), rules: [])
     }
 }

--- a/Sources/Lindenmayer/Lindenmayer.swift
+++ b/Sources/Lindenmayer/Lindenmayer.swift
@@ -44,7 +44,7 @@ public enum Lindenmayer {
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
     static func withDefines<PType, RNGType>(_ axiom: Module, prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
-        return LSystemDefinesRNG(axiom: [axiom], state: nil, newStateIndicators: nil, parameters: PWrapper(parameters), prng: RNGWrapper(prng), rules: [])
+        return LSystemDefinesRNG(axiom: [axiom], state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(prng), rules: [])
     }
 
     /// Creates a new Lindenmayer system from an initial state, using the random number generator and parameter instance that you provide.
@@ -53,6 +53,6 @@ public enum Lindenmayer {
     ///   - prng: A psuedo-random number generator to use for for randomness in rule productions.
     ///   - parameters: An instance of type you provide that the L-system provides to the rules you create for use as parameters.
     static func withDefines<PType, RNGType>(_ axiom: [Module], prng: RNGType, parameters: PType) -> LSystemDefinesRNG<PType, RNGType> {
-        return LSystemDefinesRNG(axiom: axiom, state: nil, newStateIndicators: nil, parameters: PWrapper(parameters), prng: RNGWrapper(prng), rules: [])
+        return LSystemDefinesRNG(axiom: axiom, state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(prng), rules: [])
     }
 }

--- a/Sources/Lindenmayer/Module.swift
+++ b/Sources/Lindenmayer/Module.swift
@@ -6,7 +6,7 @@
 //
 import Foundation
 
-/// A module represents an element in an L-system state array, and its parameters, if any.
+/// A module that represents a state element in an L-system state array and its parameters, if any.
 public protocol Module: CustomStringConvertible {
     /// The name of the module.
     ///

--- a/Sources/Lindenmayer/Module.swift
+++ b/Sources/Lindenmayer/Module.swift
@@ -1,6 +1,6 @@
 //
 //  Module.swift
-//  X5336
+//
 //
 //  Created by Joseph Heck on 12/9/21.
 //

--- a/Sources/Lindenmayer/ParametersWrapper.swift
+++ b/Sources/Lindenmayer/ParametersWrapper.swift
@@ -11,13 +11,13 @@ import Squirrel3
 /// A class that provides reference semantics to access an underlying parameter value type that you provide.
 public final class ParametersWrapper<PType> {
     private var _parameters: PType
-    
+
     /// Updates the wrapped parameter with the new values that you provide.
     /// - Parameter p: The value type with any included parameters.
     public func update(_ p: PType) {
         _parameters = p
     }
-    
+
     /// Returns the value type that the parameter wrapper encapsulates.
     public func unwrap() -> PType {
         return _parameters

--- a/Sources/Lindenmayer/ParametersWrapper.swift
+++ b/Sources/Lindenmayer/ParametersWrapper.swift
@@ -11,11 +11,14 @@ import Squirrel3
 /// A class that provides reference semantics to access an underlying parameter value type that you provide.
 public final class ParametersWrapper<PType> {
     private var _parameters: PType
-
+    
+    /// Updates the wrapped parameter with the new values that you provide.
+    /// - Parameter p: The value type with any included parameters.
     public func update(_ p: PType) {
         _parameters = p
     }
-
+    
+    /// Returns the value type that the parameter wrapper encapsulates.
     public func unwrap() -> PType {
         return _parameters
     }

--- a/Sources/Lindenmayer/ParametersWrapper.swift
+++ b/Sources/Lindenmayer/ParametersWrapper.swift
@@ -1,5 +1,5 @@
 //
-//  PWrapper.swift
+//  ParametersWrapper.swift
 //
 //
 //  Created by Joseph Heck on 1/4/22.
@@ -8,8 +8,8 @@
 import Foundation
 import Squirrel3
 
-/// A class that provides reference semantics to accessing an parameters value type.
-public final class PWrapper<PType> {
+/// A class that provides reference semantics to access an underlying parameter value type that you provide.
+public final class ParametersWrapper<PType> {
     private var _parameters: PType
 
     public func update(_ p: PType) {

--- a/Sources/Lindenmayer/RenderCommands.swift
+++ b/Sources/Lindenmayer/RenderCommands.swift
@@ -81,7 +81,7 @@ public enum TurtleCodes: String {
 // MARK: - RENDERING COMMAND PROTOCOLS -
 
 
-/// A type that represents a module to provide a 2D representation of an L-system.
+/// A type that represents a 2D rendered representation or a renderer command for a module within an L-System.
 ///
 /// The ``GraphicsContextRenderer`` uses 2D render commands to draw onto a canvas.
 public protocol TwoDRenderCmd {
@@ -89,7 +89,7 @@ public protocol TwoDRenderCmd {
     var name: String { get }
 }
 
-/// A type that represents a module to provide a 3D representation of an L-system.
+/// A type that represents a 3D rendered representation or a renderer command for a module within an L-System.
 ///
 /// The ``SceneKitRenderer`` uses 3D render commands to draw onto a canvas.
 public protocol ThreeDRenderCmd {

--- a/Sources/Lindenmayer/RenderCommands.swift
+++ b/Sources/Lindenmayer/RenderCommands.swift
@@ -5,6 +5,7 @@
 //
 
 import Foundation
+import SwiftUI // for the `Angle` type
 
 // MARK: - REPRESENTATION TYPES FOR RENDERING -
 
@@ -14,15 +15,28 @@ public struct ColorRepresentation: Equatable {
     let green: Double
     let blue: Double
     let alpha: Double
-
+    
+    /// Creates a new color representation using the RGB values you provide.
+    /// - Parameters:
+    ///   - r: The red value, from 0 to 1.0.
+    ///   - g: The green value, from 0 to 1.0
+    ///   - b: The blue value, from 0 to 1.0
     public init(r: Double, g: Double, b: Double) {
+        precondition(r <= 1.0 && g <= 1.0 && b <= 1.0)
         red = r
         green = g
         blue = b
         alpha = 1.0
     }
-
+    
+    /// Creates a new color representation using the red, green, blue and alpha values you provide.
+    /// - Parameters:
+    ///   - red: The red value, from 0 to 1.0.
+    ///   - green: The green value, from 0 to 1.0.
+    ///   - blue: The blue value, from 0 to 1.0.
+    ///   - alpha: The alpha value, from 0 to 1.0.
     public init(red: Double, green: Double, blue: Double, alpha: Double) {
+        precondition(red <= 1.0 && green <= 1.0 && blue <= 1.0 && alpha <= 1.0)
         self.red = red
         self.green = green
         self.blue = blue
@@ -34,7 +48,10 @@ public struct ColorRepresentation: Equatable {
     }
 }
 
-// Inspired by turtle command interpretation from the Algorithmic Beauty of Plants, pg 209
+
+/// An enumeration that identifies the types of turtle commands and provides a raw string value associated with those types.
+///
+/// The values for these strings was inspired by the turtle commands as described in [The Algorithmic Beauty of Plants](http://algorithmicbotany.org/papers/abop/abop.pdf) in the appendix, page 209.
 public enum TurtleCodes: String {
     // 2D
     case setLineWidth = "!"
@@ -53,8 +70,7 @@ public enum TurtleCodes: String {
     case rollRight = "/"
     case pitchUp = "^"
     case pitchDown = "&"
-    case spinToVertical = "$" // NOTE(heckj): un-implemented
-    case spinToHorizontal = "_" // aka @V
+    case rollToHorizontal = "$" // aka @V
     case spinVerticalTropism = "e" // NOTE(heckj): un-implemented
     // extensions for 3D objects
     case cylinder = "||"
@@ -64,13 +80,18 @@ public enum TurtleCodes: String {
 
 // MARK: - RENDERING COMMAND PROTOCOLS -
 
-// marker protocol to indicate something is a 2D rendering command
+
+/// A type that represents a module to provide a 2D representation of an L-system.
+///
+/// The ``GraphicsContextRenderer`` uses 2D render commands to draw onto a canvas.
 public protocol TwoDRenderCmd {
     /// Use a single character or very short string for the name, as it's used in textual descriptions of the state of an L-system.
     var name: String { get }
 }
 
-// marker protocol to indicate something is a 3D rendering command
+/// A type that represents a module to provide a 3D representation of an L-system.
+///
+/// The ``SceneKitRenderer`` uses 3D render commands to draw onto a canvas.
 public protocol ThreeDRenderCmd {
     /// Use a single character or very short string for the name, as it's used in textual descriptions of the state of an L-system.
     var name: String { get }
@@ -78,19 +99,27 @@ public protocol ThreeDRenderCmd {
 
 // MARK: - RENDERING COMMANDS -
 
+/// A collection of render commands, both 2D and 3D, built into Lindenmayer.
 public enum RenderCommand {
     // MARK: - BUILT-IN 2D & 3D FOCUSED MODULES -
-
+    
+    /// A value that indicates the start of a branch.
+    ///
+    /// Renderers typically use this as a marker to save the current state on a stack.
     public struct Branch: TwoDRenderCmd, ThreeDRenderCmd {
         public var name: String = TurtleCodes.branch.rawValue
         public init() {}
     }
-
+    
+    /// A value that indicates the end of a branch.
+    ///
+    /// Renderers typically use this as a marker to pop back to the previously stored state.
     public struct EndBranch: TwoDRenderCmd, ThreeDRenderCmd {
         public var name: String = TurtleCodes.endBranch.rawValue
         public init() {}
     }
-
+    
+    /// A value that indicates the state of the drawing should move forward in it's current heading by the amount you provide.
     public struct Move: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.move.rawValue
 
@@ -99,7 +128,8 @@ public enum RenderCommand {
             self.length = length
         }
     }
-
+    
+    /// A value that indicates to draw a line forward by the length you provide.
     public struct Draw: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.draw.rawValue
 
@@ -108,30 +138,34 @@ public enum RenderCommand {
             self.length = length
         }
     }
-
+    
+    /// A value that indicates the state of the drawing should turn left by the angle you provide.
     public struct TurnLeft: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.leftTurn.rawValue
 
-        public let angle: Double
-        public init(angle: Double) {
+        public let angle: Angle
+        public init(angle: Angle) {
             self.angle = angle
         }
     }
 
+    /// A value that indicates the state of the drawing should turn right by the angle you provide.
     public struct TurnRight: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.rightTurn.rawValue
 
-        public let angle: Double
-        public init(angle: Double) {
+        public let angle: Angle
+        public init(angle: Angle) {
             self.angle = angle
         }
     }
-
+    
+    /// A value that indicates the state of the drawing should ignore this module.
     public struct Ignore: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.ignore.rawValue
         public init() {}
     }
-
+    
+    /// A value that indicates the state of the drawing should update it's drawing width to the value you provide.
     public struct SetLineWidth: TwoDRenderCmd {
         public let name = TurtleCodes.setLineWidth.rawValue
         public let width: Double
@@ -139,7 +173,8 @@ public enum RenderCommand {
             self.width = width
         }
     }
-
+    
+    /// A value that indicates the state of the drawing should update it's drawing color to the color representation you provide.
     public struct SetColor: TwoDRenderCmd {
         public let name = TurtleCodes.setColor.rawValue
         public let representation: ColorRepresentation
@@ -147,47 +182,51 @@ public enum RenderCommand {
             self.representation = representation
         }
     }
-
+    
+    /// A value that indicates the state of the renderer should pitch upward from its current heading by the angle you provide.
     public struct PitchUp: ThreeDRenderCmd {
         public let name = TurtleCodes.pitchUp.rawValue
-        public let angle: Double
-        public init(angle: Double) {
+        public let angle: Angle
+        public init(angle: Angle) {
             self.angle = angle
         }
     }
 
+    /// A value that indicates the state of the renderer should pitch downward from its current heading by the angle you provide.
     public struct PitchDown: ThreeDRenderCmd {
         public let name = TurtleCodes.pitchDown.rawValue
-        public let angle: Double
-        public init(angle: Double) {
+        public let angle: Angle
+        public init(angle: Angle) {
             self.angle = angle
         }
     }
 
+    /// A value that indicates the state of the renderer should roll to the right around its current heading by the angle you provide.
     public struct RollRight: ThreeDRenderCmd {
         public let name = TurtleCodes.rollRight.rawValue
-        public let angle: Double
-        public init(angle: Double) {
+        public let angle: Angle
+        public init(angle: Angle) {
             self.angle = angle
         }
     }
 
+    /// A value that indicates the state of the renderer should roll to the left around its current heading by the angle you provide.
     public struct RollLeft: ThreeDRenderCmd {
         public let name = TurtleCodes.rollLeft.rawValue
-        public let angle: Double
-        public init(angle: Double) {
+        public let angle: Angle
+        public init(angle: Angle) {
             self.angle = angle
         }
     }
-
-    public struct SpinToFlat: ThreeDRenderCmd {
-        public let name = TurtleCodes.spinToHorizontal.rawValue
+    
+    /// A value that indicates the state of the renderer should roll around its current heading so that the upward vector is as vertical as possible.
+    public struct RollToHorizontal: ThreeDRenderCmd {
+        public let name = TurtleCodes.rollToHorizontal.rawValue
     }
-
-    public struct SpinToVertical: ThreeDRenderCmd {
-        public let name = TurtleCodes.spinToVertical.rawValue
-    }
-
+    
+    /// A value that indicates the renderer should create a 3D cylinder of the radius, length, and color representation that you provide.
+    ///
+    /// The renderer is expected to also move forward, updating it's state to a position at the end of the cylinder.
     public struct Cylinder: ThreeDRenderCmd {
         public let name = TurtleCodes.cylinder.rawValue
         public let length: Double
@@ -200,6 +239,9 @@ public enum RenderCommand {
         }
     }
 
+    /// A value that indicates the renderer should create a 3D cylinder of the length, top radius, bottom radius, and color representation that you provide at the current location.
+    ///
+    /// The renderer is expected to also move forward, updating it's state to a position at the end of the cone.
     public struct Cone: ThreeDRenderCmd {
         public let name = TurtleCodes.cone.rawValue
         public let length: Double
@@ -213,7 +255,8 @@ public enum RenderCommand {
             self.color = color
         }
     }
-
+    
+    /// A value that indicates the rendered should create a 3D sphere of the radius you provide at the current location.
     public struct Sphere: ThreeDRenderCmd {
         public let name = TurtleCodes.sphere.rawValue
         public let radius: Double
@@ -225,29 +268,44 @@ public enum RenderCommand {
     }
 
     // 2D ONLY
+    /// A value that indicates to set the line width of the renderer to 1.0.
     public static var setLineWidth = SetLineWidth(width: 1)
+    /// A value that indicates to set the color representation for the renderer to black.
     public static var setColor = SetColor(representation: ColorRepresentation(r: 0.0, g: 0.0, b: 0.0))
 
     // 2D and 3D
+    /// A value that indicates the renderer should move forward by a length of 1.0.
     public static var move = Move(length: 1.0)
+    /// A value that indicates the renderer should draw a line forward at a length of 1.0.
     public static var draw = Draw(length: 1.0)
-
-    public static var turnLeft = TurnLeft(angle: 90)
-    public static var turnRight = TurnRight(angle: 90)
-
+    
+    /// A value that indicates the renderer should turn left by 90°.
+    public static var turnLeft = TurnLeft(angle: .degrees(90))
+    /// A value that indicates the renderer should turn right by 90°.
+    public static var turnRight = TurnRight(angle: .degrees(90))
+    /// A value that indicates the start of a branch.
     public static var branch = Branch()
+    /// A value that indicates the end of a branch.
     public static var endBranch = EndBranch()
 
     // 3D ONLY
-    public static var pitchUp = PitchUp(angle: 30)
-    public static var pitchDown = PitchDown(angle: 30)
+    /// A value that indicates the renderer should pitch up by 30°.
+    public static var pitchUp = PitchUp(angle: .degrees(30))
+    /// A value that indicates the renderer should pitch down by 30°.
+    public static var pitchDown = PitchDown(angle: .degrees(30))
 
-    public static var rollRight = RollRight(angle: 90)
-    public static var rollLeft = RollLeft(angle: 90)
+    /// A value that indicates the renderer should roll right by 90°.
+    public static var rollRight = RollRight(angle: .degrees(90))
+    /// A value that indicates the renderer should roll left by 90°.
+    public static var rollLeft = RollLeft(angle: .degrees(90))
 
-    public static var spinToFlat = SpinToFlat()
+    /// A value that indicates the state of the renderer should roll around its current heading so that the upward vector is as vertical as possible.
+    public static var rollToHorizontal = RollToHorizontal()
 
+    /// A value that indicates the renderer should display a cylinder of length 1.0 and radius 0.1, moving forward by 1.0.
     public static var cylinder = Cylinder(length: 1, radius: 0.1)
+    /// A value that indicates the renderer should display a cone of length 1.0, bottom radius of 0.1, top radius of 0, and moving forward by 1.0.
     public static var cone = Cone(length: 1, radiusTop: 0, radiusBottom: 0.1)
+    /// A value that indicates the renderer should display a sphere of radius 0.1.
     public static var sphere = Sphere(radius: 0.1)
 }

--- a/Sources/Lindenmayer/RenderCommands.swift
+++ b/Sources/Lindenmayer/RenderCommands.swift
@@ -15,7 +15,7 @@ public struct ColorRepresentation: Equatable {
     let green: Double
     let blue: Double
     let alpha: Double
-    
+
     /// Creates a new color representation using the RGB values you provide.
     /// - Parameters:
     ///   - r: The red value, from 0 to 1.0.
@@ -28,7 +28,7 @@ public struct ColorRepresentation: Equatable {
         blue = b
         alpha = 1.0
     }
-    
+
     /// Creates a new color representation using the red, green, blue and alpha values you provide.
     /// - Parameters:
     ///   - red: The red value, from 0 to 1.0.
@@ -47,7 +47,6 @@ public struct ColorRepresentation: Equatable {
         return ColorRepresentation(r: 0, g: 0, b: 0)
     }
 }
-
 
 /// An enumeration that identifies the types of turtle commands and provides a raw string value associated with those types.
 ///
@@ -70,7 +69,7 @@ public enum TurtleCodes: String {
     case rollRight = "/"
     case pitchUp = "^"
     case pitchDown = "&"
-    case rollToHorizontal = "$" // aka @V
+    case rollUpToVertical = "$" // aka @V
     case spinVerticalTropism = "e" // NOTE(heckj): un-implemented
     // extensions for 3D objects
     case cylinder = "||"
@@ -79,7 +78,6 @@ public enum TurtleCodes: String {
 }
 
 // MARK: - RENDERING COMMAND PROTOCOLS -
-
 
 /// A type that represents a 2D rendered representation or a renderer command for a module within an L-System.
 ///
@@ -102,7 +100,7 @@ public protocol ThreeDRenderCmd {
 /// A collection of render commands, both 2D and 3D, built into Lindenmayer.
 public enum RenderCommand {
     // MARK: - BUILT-IN 2D & 3D FOCUSED MODULES -
-    
+
     /// A value that indicates the start of a branch.
     ///
     /// Renderers typically use this as a marker to save the current state on a stack.
@@ -110,7 +108,7 @@ public enum RenderCommand {
         public var name: String = TurtleCodes.branch.rawValue
         public init() {}
     }
-    
+
     /// A value that indicates the end of a branch.
     ///
     /// Renderers typically use this as a marker to pop back to the previously stored state.
@@ -118,7 +116,7 @@ public enum RenderCommand {
         public var name: String = TurtleCodes.endBranch.rawValue
         public init() {}
     }
-    
+
     /// A value that indicates the state of the drawing should move forward in it's current heading by the amount you provide.
     public struct Move: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.move.rawValue
@@ -128,7 +126,7 @@ public enum RenderCommand {
             self.length = length
         }
     }
-    
+
     /// A value that indicates to draw a line forward by the length you provide.
     public struct Draw: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.draw.rawValue
@@ -138,7 +136,7 @@ public enum RenderCommand {
             self.length = length
         }
     }
-    
+
     /// A value that indicates the state of the drawing should turn left by the angle you provide.
     public struct TurnLeft: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.leftTurn.rawValue
@@ -158,13 +156,13 @@ public enum RenderCommand {
             self.angle = angle
         }
     }
-    
+
     /// A value that indicates the state of the drawing should ignore this module.
     public struct Ignore: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.ignore.rawValue
         public init() {}
     }
-    
+
     /// A value that indicates the state of the drawing should update it's drawing width to the value you provide.
     public struct SetLineWidth: TwoDRenderCmd {
         public let name = TurtleCodes.setLineWidth.rawValue
@@ -173,7 +171,7 @@ public enum RenderCommand {
             self.width = width
         }
     }
-    
+
     /// A value that indicates the state of the drawing should update it's drawing color to the color representation you provide.
     public struct SetColor: TwoDRenderCmd {
         public let name = TurtleCodes.setColor.rawValue
@@ -182,7 +180,7 @@ public enum RenderCommand {
             self.representation = representation
         }
     }
-    
+
     /// A value that indicates the state of the renderer should pitch upward from its current heading by the angle you provide.
     public struct PitchUp: ThreeDRenderCmd {
         public let name = TurtleCodes.pitchUp.rawValue
@@ -218,12 +216,12 @@ public enum RenderCommand {
             self.angle = angle
         }
     }
-    
+
     /// A value that indicates the state of the renderer should roll around its current heading so that the upward vector is as vertical as possible.
-    public struct RollToHorizontal: ThreeDRenderCmd {
-        public let name = TurtleCodes.rollToHorizontal.rawValue
+    public struct RollUpToVertical: ThreeDRenderCmd {
+        public let name = TurtleCodes.rollUpToVertical.rawValue
     }
-    
+
     /// A value that indicates the renderer should create a 3D cylinder of the radius, length, and color representation that you provide.
     ///
     /// The renderer is expected to also move forward, updating it's state to a position at the end of the cylinder.
@@ -255,7 +253,7 @@ public enum RenderCommand {
             self.color = color
         }
     }
-    
+
     /// A value that indicates the rendered should create a 3D sphere of the radius you provide at the current location.
     public struct Sphere: ThreeDRenderCmd {
         public let name = TurtleCodes.sphere.rawValue
@@ -278,7 +276,7 @@ public enum RenderCommand {
     public static var move = Move(length: 1.0)
     /// A value that indicates the renderer should draw a line forward at a length of 1.0.
     public static var draw = Draw(length: 1.0)
-    
+
     /// A value that indicates the renderer should turn left by 90°.
     public static var turnLeft = TurnLeft(angle: .degrees(90))
     /// A value that indicates the renderer should turn right by 90°.
@@ -300,7 +298,7 @@ public enum RenderCommand {
     public static var rollLeft = RollLeft(angle: .degrees(90))
 
     /// A value that indicates the state of the renderer should roll around its current heading so that the upward vector is as vertical as possible.
-    public static var rollToHorizontal = RollToHorizontal()
+    public static var rollUpToVertical = RollUpToVertical()
 
     /// A value that indicates the renderer should display a cylinder of length 1.0 and radius 0.1, moving forward by 1.0.
     public static var cylinder = Cylinder(length: 1, radius: 0.1)

--- a/Sources/Lindenmayer/RewriteRuleDirectDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectDefines.swift
@@ -12,7 +12,7 @@ public struct RewriteRuleDirectDefines<DC, PType>: Rule where DC: Module {
     public var parametricEval: ((DC, PType) -> Bool)?
 
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     /// The signature of the produce closure that provides a module and expects a sequence of modules.
     public typealias singleMatchProducesList = (DC, PType) -> [Module]
@@ -29,7 +29,7 @@ public struct RewriteRuleDirectDefines<DC, PType>: Rule where DC: Module {
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType direct: DC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 where _: ((DC, PType) -> Bool)?,
                 produces singleModuleProduce: @escaping singleMatchProducesList)
     {

--- a/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
@@ -13,7 +13,7 @@ public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Modul
     public var parametricEval: ((DC, PType) -> Bool)?
 
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -33,7 +33,7 @@ public struct RewriteRuleDirectDefinesRNG<DC, PType, PRNG>: Rule where DC: Modul
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType direct: DC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((DC, PType) -> Bool)?,
                 produces singleModuleProduce: @escaping singleMatchProducesList)

--- a/Sources/Lindenmayer/RewriteRuleDirectRightDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightDefines.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleDirectRightDefines<DC, RC, PType>: Rule where DC: Module, RC: Module {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     public var parametricEval: ((DC, RC, PType) -> Bool)?
 
@@ -29,7 +29,7 @@ public struct RewriteRuleDirectRightDefines<DC, RC, PType>: Rule where DC: Modul
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType: DC.Type, rightType: RC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 where _: ((DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
     {

--- a/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
@@ -10,7 +10,7 @@ import Squirrel3
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -32,7 +32,7 @@ public struct RewriteRuleDirectRightDefinesRNG<DC, RC, PType, PRNG>: Rule where 
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(directType: DC.Type, rightType: RC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectDefines.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectDefines<LC, DC, PType>: Rule where LC: Module, DC: Module {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     public var parametricEval: ((LC, DC, PType) -> Bool)?
 
@@ -29,7 +29,7 @@ public struct RewriteRuleLeftDirectDefines<LC, DC, PType>: Rule where LC: Module
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 where _: ((LC, DC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
     {

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
@@ -11,7 +11,7 @@ import Squirrel3
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where LC: Module, DC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -33,7 +33,7 @@ public struct RewriteRuleLeftDirectDefinesRNG<LC, DC, PType, PRNG>: Rule where L
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((LC, DC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefines.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefines.swift
@@ -10,7 +10,7 @@ import Foundation
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectRightDefines<LC, DC, RC, PType>: Rule where LC: Module, DC: Module, RC: Module {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     public var parametricEval: ((LC, DC, RC, PType) -> Bool)?
 
@@ -29,7 +29,7 @@ public struct RewriteRuleLeftDirectRightDefines<LC, DC, RC, PType>: Rule where L
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type, rightType: RC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 where _: ((LC, DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)
     {

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
@@ -11,7 +11,7 @@ import Squirrel3
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rule where LC: Module, DC: Module, RC: Module, PRNG: SeededRandomNumberGenerator {
     /// The set of parameters provided by the L-system for rule evaluation and production.
-    var parameters: PWrapper<PType>
+    var parameters: ParametersWrapper<PType>
 
     /// A psuedo-random number generator to use for stochastic rule productions.
     var prng: RNGWrapper<PRNG>
@@ -33,7 +33,7 @@ public struct RewriteRuleLeftDirectRightDefinesRNG<LC, DC, RC, PType, PRNG>: Rul
     ///   - prng: An optional psuedo-random number generator to use for stochastic rule productions.
     ///   - singleModuleProduce: A closure that produces an array of L-system state elements to use in place of the current element.
     public init(leftType: LC.Type, directType: DC.Type, rightType: RC.Type,
-                parameters: PWrapper<PType>,
+                parameters: ParametersWrapper<PType>,
                 prng: RNGWrapper<PRNG>,
                 where _: ((LC, DC, RC, PType) -> Bool)?,
                 produces produceClosure: @escaping combinationMatchProducesList)

--- a/Sources/Lindenmayer/Rule.swift
+++ b/Sources/Lindenmayer/Rule.swift
@@ -6,7 +6,7 @@
 
 import Foundation
 
-/// A type that represents a rewriting rule used by an L-system to process the modules within it.
+/// A type that represents a rewriting rule used by an L-system to process its modules.
 public protocol Rule {
     /// Returns a Boolean value that indicates whether the rule applies to the set of modules you provide.
     func evaluate(_ matchSet: ModuleSet) -> Bool

--- a/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
+++ b/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
@@ -13,10 +13,10 @@ extension simd_float4x4 {
     /// - Parameter indent: If provided, the string to use as a prefix for each line.
     public func prettyPrintString(_ indent: String = "") -> String {
         var result = ""
-        result += "\(indent)[\(columns.0.x), \(columns.0.y), \(columns.0.z), \(columns.0.w)]\n"
-        result += "\(indent)[\(columns.1.x), \(columns.1.y), \(columns.1.z), \(columns.1.w)]\n"
-        result += "\(indent)[\(columns.2.x), \(columns.2.y), \(columns.2.z), \(columns.2.w)]\n"
-        result += "\(indent)[\(columns.3.x), \(columns.3.y), \(columns.3.z), \(columns.3.w)]\n"
+        result += "\(indent)[\(columns.0.x), \(columns.1.x), \(columns.2.x), \(columns.3.x)]\n"
+        result += "\(indent)[\(columns.0.y), \(columns.1.y), \(columns.2.y), \(columns.3.y)]\n"
+        result += "\(indent)[\(columns.0.z), \(columns.1.z), \(columns.2.z), \(columns.3.z)]\n"
+        result += "\(indent)[\(columns.0.w), \(columns.1.w), \(columns.2.w), \(columns.3.w)]\n"
         return result
     }
 
@@ -34,9 +34,14 @@ extension simd_float4x4 {
     /// Calculate a normalized heading vector, originally vertical, using a 4x4 state transform
     /// - Returns: a 3D unit vector of the heading
     public func headingVector() -> simd_float3 {
-        let original_heading_vector = simd_float3(x: 0, y: 1, z: 0)
-        let rotated_heading = matrix_multiply(self.rotationTransform, original_heading_vector)
-        return rotated_heading
+//        // full affine method
+//        let original_heading_vector = simd_float4(x: 0, y: 1, z: 0, w: 1)
+//        let rotated_heading_4 = matrix_multiply(self, original_heading_vector)
+//        return simd_float3(x: rotated_heading_4.x, y: rotated_heading_4.y, z:rotated_heading_4.z)
+        // pulling just the transform out:
+        let short_heading_vector = simd_float3(x: 0, y: 1, z: 0)
+        let rotated_heading_3 = matrix_multiply(self.rotationTransform, short_heading_vector)
+        return rotated_heading_3
     }
 
     public func angleFromVertical() -> Float {
@@ -45,5 +50,11 @@ extension simd_float4x4 {
         let dot = simd_dot(northpole, heading)
         let calc_angle = acos(dot) / (simd_length(heading) * simd_length(northpole))
         return calc_angle
+    }
+}
+
+public extension Comparable {
+    func clamped(to limits: ClosedRange<Self>) -> Self {
+        return min(max(self, limits.lowerBound), limits.upperBound)
     }
 }

--- a/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
+++ b/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
@@ -1,5 +1,5 @@
 //
-//  File.swift
+//  SIMD_Float4x4+Extensions.swift
 //
 //
 //  Created by Joseph Heck on 1/3/22.

--- a/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
+++ b/Sources/Lindenmayer/SIMD_Float4x4+Extensions.swift
@@ -11,7 +11,7 @@ import simd
 extension simd_float4x4 {
     /// Returns a multi-line string that represents the simd4x4 matrix for easier visual reading.
     /// - Parameter indent: If provided, the string to use as a prefix for each line.
-    func prettyPrintString(_ indent: String = "") -> String {
+    public func prettyPrintString(_ indent: String = "") -> String {
         var result = ""
         result += "\(indent)[\(columns.0.x), \(columns.0.y), \(columns.0.z), \(columns.0.w)]\n"
         result += "\(indent)[\(columns.1.x), \(columns.1.y), \(columns.1.z), \(columns.1.w)]\n"
@@ -20,7 +20,7 @@ extension simd_float4x4 {
         return result
     }
 
-    func rotationTransform() -> matrix_float3x3 {
+    public var rotationTransform: matrix_float3x3 {
         // extract the rotational component from the transform matrix
         let (col1, col2, col3, _) = columns
         let rotationTransform = matrix_float3x3(
@@ -33,21 +33,13 @@ extension simd_float4x4 {
 
     /// Calculate a normalized heading vector, originally vertical, using a 4x4 state transform
     /// - Returns: a 3D unit vector of the heading
-    func headingVector() -> simd_float3 {
-        // extract the rotational component from the transform matrix
-        let (col1, col2, col3, _) = columns
-        let rotationTransform = matrix_float3x3(
-            simd_float3(x: col1.x, y: col1.y, z: col1.z),
-            simd_float3(x: col2.x, y: col2.y, z: col2.z),
-            simd_float3(x: col3.x, y: col3.y, z: col3.z)
-        )
+    public func headingVector() -> simd_float3 {
         let original_heading_vector = simd_float3(x: 0, y: 1, z: 0)
-        let rotated_heading = matrix_multiply(rotationTransform, original_heading_vector)
-        // should be length=1 already, but just in case...
-        return simd_normalize(rotated_heading)
+        let rotated_heading = matrix_multiply(self.rotationTransform, original_heading_vector)
+        return rotated_heading
     }
 
-    func angleFromVertical() -> Float {
+    public func angleFromVertical() -> Float {
         let northpole = simd_float3(x: 0, y: 1, z: 0)
         let heading = headingVector()
         let dot = simd_dot(northpole, heading)

--- a/Sources/Lindenmayer/SceneKitRenderer.swift
+++ b/Sources/Lindenmayer/SceneKitRenderer.swift
@@ -6,6 +6,7 @@
 //
 
 import CoreGraphics
+import SwiftUI // for `Angle`
 import Foundation
 import SceneKit
 import simd
@@ -66,7 +67,7 @@ public struct SceneKitRenderer {
     func addDebugFlooring(_ scene: SCNScene, grid: Bool = true) {
         let flooring = SCNNode(geometry: SCNPlane(width: 10, height: 10))
         flooring.geometry?.materials = [material(red: 0.1, green: 0.7, blue: 0.1, alpha: 0.5)]
-        flooring.simdEulerAngles = simd_float3(x: degreesToRadians(-90), y: 0, z: 0)
+        flooring.simdEulerAngles = simd_float3(x: Float(Angle(degrees: -90).radians), y: 0, z: 0)
 
         let axisMaterials = [material(red: 0.0, green: 0.0, blue: 0.0, alpha: 1.0)]
 
@@ -81,10 +82,10 @@ public struct SceneKitRenderer {
         let zaxis = SCNNode(geometry: lowresCyl)
         flooring.addChildNode(zaxis)
         let xaxis = SCNNode(geometry: lowresCyl)
-        xaxis.simdEulerAngles = simd_float3(x: 0, y: 0, z: degreesToRadians(90))
+        xaxis.simdEulerAngles = simd_float3(x: 0, y: 0, z: Float(Angle(degrees: 90).radians))
         flooring.addChildNode(xaxis)
         let yaxis = SCNNode(geometry: lowresCyl)
-        yaxis.simdEulerAngles = simd_float3(x: degreesToRadians(90), y: 0, z: 0)
+        yaxis.simdEulerAngles = simd_float3(x: Float(Angle(degrees: 90).radians), y: 0, z: 0)
         flooring.addChildNode(yaxis)
 
         if grid {
@@ -128,7 +129,7 @@ public struct SceneKitRenderer {
             case TurtleCodes.pitchUp.rawValue:
                 // positive values pitch nose up (positive rotation around X axis)
                 if let cmd = cmd as? RenderCommand.PitchUp {
-                    let directionAngleInRadians: Float = degreesToRadians(cmd.angle)
+                    let directionAngleInRadians = Float(cmd.angle.radians)
                     let pitchTransform = rotationAroundXAxisTransform(angle: directionAngleInRadians)
                     currentState = currentState.applyingTransform(pitchTransform)
 //                    print("Pitch (rotate around +X Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
@@ -137,7 +138,7 @@ public struct SceneKitRenderer {
             case TurtleCodes.pitchDown.rawValue:
                 // negative values pitch nose down (negative rotation around X axis)
                 if let cmd = cmd as? RenderCommand.PitchDown {
-                    let directionAngleInRadians: Float = -1.0 * degreesToRadians(cmd.angle)
+                    let directionAngleInRadians = -1.0 * Float(cmd.angle.radians)
                     let pitchTransform = rotationAroundXAxisTransform(angle: directionAngleInRadians)
                     currentState = currentState.applyingTransform(pitchTransform)
 //                    print("Pitch (rotate around -X Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
@@ -146,7 +147,7 @@ public struct SceneKitRenderer {
             case TurtleCodes.rollLeft.rawValue:
                 if let cmd = cmd as? RenderCommand.RollLeft {
                     // negative values roll to the left (negative rotation around Y axis)
-                    let directionAngleInRadians: Float = -1.0 * degreesToRadians(cmd.angle)
+                    let directionAngleInRadians = -1.0 * Float(cmd.angle.radians)
                     let rollTransform = rotationAroundYAxisTransform(angle: directionAngleInRadians)
                     currentState = currentState.applyingTransform(rollTransform)
 //                    print("Roll (rotate around -Y Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
@@ -155,7 +156,7 @@ public struct SceneKitRenderer {
             case TurtleCodes.rollRight.rawValue:
                 if let cmd = cmd as? RenderCommand.RollRight {
                     // positive values roll to the right (positive rotation around Y axis)
-                    let directionAngleInRadians: Float = degreesToRadians(cmd.angle)
+                    let directionAngleInRadians = Float(cmd.angle.radians)
                     let rollTransform = rotationAroundYAxisTransform(angle: directionAngleInRadians)
                     currentState = currentState.applyingTransform(rollTransform)
 //                    print("Roll (rotate around +Y Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
@@ -164,7 +165,7 @@ public struct SceneKitRenderer {
             case TurtleCodes.leftTurn.rawValue:
                 if let cmd = cmd as? RenderCommand.TurnLeft {
                     // positive values turn to the left (positive rotation around Z axis)
-                    let directionAngleInRadians: Float = degreesToRadians(cmd.angle)
+                    let directionAngleInRadians = Float(cmd.angle.radians)
                     let yawTransform = rotationAroundZAxisTransform(angle: directionAngleInRadians)
                     currentState = currentState.applyingTransform(yawTransform)
 //                    print("Yaw (rotate around +Z Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
@@ -173,13 +174,13 @@ public struct SceneKitRenderer {
             case TurtleCodes.rightTurn.rawValue:
                 if let cmd = cmd as? RenderCommand.TurnRight {
                     // negative values turn to the right (negative rotation around Z axis)
-                    let directionAngleInRadians: Float = -1.0 * degreesToRadians(cmd.angle)
+                    let directionAngleInRadians = -1.0 * Float(cmd.angle.radians)
                     let yawTransform = rotationAroundZAxisTransform(angle: directionAngleInRadians)
                     currentState = currentState.applyingTransform(yawTransform)
 //                    print("Yaw (rotate around -Z Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
                 }
 
-            case TurtleCodes.spinToHorizontal.rawValue:
+            case TurtleCodes.rollToHorizontal.rawValue:
                 // The interpretation of this symbol is a tricky beast. From pg 41 of
                 // http://algorithmicbotany.org/papers/hanan.dis1992.pdf
                 // 'PARAMETRIC L-SYSTEMS AND THEIR APPLICATION TO THE MODELLING AND VISUALIZATION OF PLANTS'
@@ -303,15 +304,5 @@ public struct SceneKitRenderer {
         cameraNode.simdLook(at: simd_float3(x: 0, y: Float(distance) / 2.0, z: 0))
 
         return (scene, transformSequence)
-    }
-
-    // MARK: - Internal
-
-    func degreesToRadians(_ value: Double) -> Float {
-        return Float(value * .pi / 180.0)
-    }
-
-    func degrees(radians: Float) -> Float {
-        return radians / .pi * 180.0
     }
 }

--- a/Sources/Lindenmayer/SceneKitRenderer.swift
+++ b/Sources/Lindenmayer/SceneKitRenderer.swift
@@ -6,10 +6,10 @@
 //
 
 import CoreGraphics
-import SwiftUI // for `Angle`
 import Foundation
 import SceneKit
 import simd
+import SwiftUI // for `Angle`
 
 struct GrowthState {
     var transform: simd_float4x4
@@ -103,7 +103,7 @@ public struct SceneKitRenderer {
 
         scene.rootNode.addChildNode(flooring)
     }
-    
+
     /// Generates a SceneKit scene from the L-system that you provide.
     /// - Parameter lsystem: The L-system to render into a 3D scene.
     /// - Returns: A SceneKit scene rendered from the L-system.
@@ -112,7 +112,7 @@ public struct SceneKitRenderer {
     public func generateScene(lsystem: LSystem) -> SCNScene {
         generateScene(lsystem: lsystem).0
     }
-    
+
     /// Generates a SceneKit scene from the L-system that you provide.
     /// - Parameter lsystem: The L-system to render into a 3D scene.
     /// - Returns: A tuple of the rendered SceneKit scene and an array of transforms that represent each module's state transition while rendering the scene.
@@ -192,7 +192,7 @@ public struct SceneKitRenderer {
 //                    print("Yaw (rotate around -Z Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
                 }
 
-            case TurtleCodes.rollToHorizontal.rawValue:
+            case TurtleCodes.rollUpToVertical.rawValue:
                 // The interpretation of this symbol is a tricky beast. From pg 41 of
                 // http://algorithmicbotany.org/papers/hanan.dis1992.pdf
                 // 'PARAMETRIC L-SYSTEMS AND THEIR APPLICATION TO THE MODELLING AND VISUALIZATION OF PLANTS'

--- a/Sources/Lindenmayer/SceneKitRenderer.swift
+++ b/Sources/Lindenmayer/SceneKitRenderer.swift
@@ -237,7 +237,7 @@ public struct SceneKitRenderer {
 
             case TurtleCodes.rollUpToVertical.rawValue:
                 let resulting_angle = rotateAroundHeadingToVertical(currentState.transform)
-                let rotationTransform = rotationAroundYAxisTransform(angle: resulting_angle)
+                let rotationTransform = rotationAroundYAxisTransform(angle: -resulting_angle)
                 currentState = currentState.applyingTransform(rotationTransform)
 
             case TurtleCodes.move.rawValue:

--- a/Sources/Lindenmayer/SceneKitRenderer.swift
+++ b/Sources/Lindenmayer/SceneKitRenderer.swift
@@ -48,6 +48,7 @@ struct GrowthState {
 }
 
 extension ColorRepresentation {
+    /// Provides a SceneKit material based on the color representation values.
     var material: SCNMaterial {
         let material = SCNMaterial()
         material.diffuse.contents = CGColor(red: red, green: green, blue: blue, alpha: alpha)
@@ -55,6 +56,7 @@ extension ColorRepresentation {
     }
 }
 
+/// A renderer that generates a 3D graphical representation of an L-system using SceneKit.
 public struct SceneKitRenderer {
     public init() {}
 
@@ -101,11 +103,21 @@ public struct SceneKitRenderer {
 
         scene.rootNode.addChildNode(flooring)
     }
-
+    
+    /// Generates a SceneKit scene from the L-system that you provide.
+    /// - Parameter lsystem: The L-system to render into a 3D scene.
+    /// - Returns: A SceneKit scene rendered from the L-system.
+    ///
+    /// The scene includes a camera node identified as `camera`, and a plane to represent the floor and scale of the scene.
     public func generateScene(lsystem: LSystem) -> SCNScene {
         generateScene(lsystem: lsystem).0
     }
-
+    
+    /// Generates a SceneKit scene from the L-system that you provide.
+    /// - Parameter lsystem: The L-system to render into a 3D scene.
+    /// - Returns: A tuple of the rendered SceneKit scene and an array of transforms that represent each module's state transition while rendering the scene.
+    ///
+    /// The scene includes a camera node identified as `camera`, and a plane to represent the floor and scale of the scene.
     public func generateScene(lsystem: LSystem) -> (SCNScene, [matrix_float4x4]) {
         let scene = SCNScene()
         // create and add a camera to the scene

--- a/Sources/LindenmayerViews/Dynamic2DLSystemViews.swift
+++ b/Sources/LindenmayerViews/Dynamic2DLSystemViews.swift
@@ -1,6 +1,6 @@
 //
-//  SwiftUIView.swift
-//  X5336
+//  Dynamic2DLSystemViews.swift
+//
 //
 //  Created by Joseph Heck on 12/15/21.
 //
@@ -8,8 +8,9 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that allows you to choose from a collection of the built-in 2D L-systems and display the 2D representation of the L-system at the number of iterations that you select in the view.
 @available(macOS 12.0, iOS 15.0, *)
-public struct DynamicLSystemView: View {
+public struct Dynamic2DLSystemViews: View {
     @State private var evolutions: Double = 0
     @State private var selectedSystem = Examples2D.fractalTree
     public var body: some View {
@@ -33,14 +34,15 @@ public struct DynamicLSystemView: View {
                 }
             }
             .padding()
-            Lsystem2DView(system: selectedSystem.lsystem.evolved(iterations: Int(evolutions)))
+            Lsystem2DView(system: selectedSystem.lsystem.evolved(iterations: Int(evolutions)),
+                          displayMetrics: false)
         }
     }
 }
 
 @available(macOS 12.0, iOS 15.0, *)
-struct DynamicLSystemView_Previews: PreviewProvider {
+struct Dynamic2DLSystemViews_Previews: PreviewProvider {
     static var previews: some View {
-        DynamicLSystemView()
+        Dynamic2DLSystemViews()
     }
 }

--- a/Sources/LindenmayerViews/HorizontalLSystemStateView.swift
+++ b/Sources/LindenmayerViews/HorizontalLSystemStateView.swift
@@ -1,5 +1,5 @@
 //
-//  SwiftUIView.swift
+//  HorizontalLSystemStateView.swift
 //
 //
 //  Created by Joseph Heck on 1/11/22.
@@ -8,8 +8,9 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that displays a horizontal collection of summary of the modules of an Lsystem at the size choice you provide.
 @available(macOS 12.0, iOS 15.0, *)
-public struct HorizontalSummarySequence: View {
+public struct HorizontalLSystemStateView: View {
     let size: SummarySizes
     let system: LSystem
     public var body: some View {
@@ -28,11 +29,11 @@ public struct HorizontalSummarySequence: View {
 }
 
 @available(macOS 12.0, iOS 15.0, *)
-struct HorizontalSummarySequence_Previews: PreviewProvider {
+struct HorizontalLSystemStateView_Previews: PreviewProvider {
     static var previews: some View {
         let system = Examples3D.monopodialTree.lsystem.evolved(iterations: 4)
         ForEach(SummarySizes.allCases, id: \.self) { sizeChoice in
-            HorizontalSummarySequence(size: sizeChoice, system: system)
+            HorizontalLSystemStateView(size: sizeChoice, system: system)
         }
     }
 }

--- a/Sources/LindenmayerViews/LSystem3DControlView.swift
+++ b/Sources/LindenmayerViews/LSystem3DControlView.swift
@@ -1,6 +1,6 @@
 //
 //  LSystem3DControlView.swift
-//  
+//
 //
 //  Created by Joseph Heck on 1/8/22.
 //

--- a/Sources/LindenmayerViews/LSystem3DControlView.swift
+++ b/Sources/LindenmayerViews/LSystem3DControlView.swift
@@ -1,6 +1,6 @@
 //
-//  SystemControlView.swift
-//  X5336
+//  LSystem3DControlView.swift
+//  
 //
 //  Created by Joseph Heck on 1/8/22.
 //
@@ -10,6 +10,11 @@ import SceneKit
 import SceneKitDebugTools
 import SwiftUI
 
+/// A view that displays a 3D representation of an Lsystem, allowing the person viewing it to control the 3D visualization.
+///
+/// The controls within the view allow you to select the number of iterations for the L-system.
+/// Within the resulting L-system's state, you can select each state of the L-system, which points the 3D camera at that node and highlights it.
+/// The view is intended to provide a visualization with sufficient detail about the state and its representation for debugging how an L-system is represented in 3D.
 public struct LSystem3DControlView: View {
     var model: LSystem3DModel
     @State private var iterations = 1
@@ -17,7 +22,7 @@ public struct LSystem3DControlView: View {
     @State private var autoLookAt = true
     @State private var currentNode: SCNNode? = nil
 
-    /// Adjusts the camera node to point towards another SCNNode you provide, and optionally highlight that node temporarily.
+    /// Points the node for the camera towards another node you identify, and optionally highlights it temporarily.
     /// - Parameters:
     ///   - selectedNode: The node to look at.
     ///   - cameraNode: The camera node to manipulate.

--- a/Sources/LindenmayerViews/LSystem3DModel.swift
+++ b/Sources/LindenmayerViews/LSystem3DModel.swift
@@ -1,6 +1,6 @@
 //
 //  LSystem3DModel.swift
-//  X5336
+//
 //
 //  Created by Joseph Heck on 1/8/22.
 //
@@ -12,6 +12,10 @@ import SceneKit
 import SceneKitDebugTools
 import SwiftUI
 
+/// A class that provides an observable model around a base L-system.
+///
+/// The module manages the number of evolutions of an L-system, and provides updated 3D SceneKit scenes as you change the number of evolutions.
+/// The model emits `ObservableObject` change notifications when the number of iterations is changed.
 public class LSystem3DModel: ObservableObject {
     @Published public var system: LSystem
     let renderer = SceneKitRenderer()

--- a/Sources/LindenmayerViews/LSystemMetrics.swift
+++ b/Sources/LindenmayerViews/LSystemMetrics.swift
@@ -1,6 +1,6 @@
 //
 //  LSystemMetrics.swift
-//  
+//
 //
 //  Created by Joseph Heck on 12/16/21.
 //

--- a/Sources/LindenmayerViews/LSystemMetrics.swift
+++ b/Sources/LindenmayerViews/LSystemMetrics.swift
@@ -1,6 +1,6 @@
 //
 //  LSystemMetrics.swift
-//  X5336
+//  
 //
 //  Created by Joseph Heck on 12/16/21.
 //
@@ -8,6 +8,7 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that provides the size of the state of an L-system and a textual representation of that state.
 public struct LSystemMetrics: View {
     let system: LSystem
     public var body: some View {

--- a/Sources/LindenmayerViews/LindenmayerViews.docc/LindenmayerViews.md
+++ b/Sources/LindenmayerViews/LindenmayerViews.docc/LindenmayerViews.md
@@ -1,6 +1,6 @@
 # ``LindenmayerViews``
 
-LindenmayerViews provides a collection of SwiftUI views to display the results 2D and 3D L-systems that you create with ``Lindenmayer``.
+LindenmayerViews provides a collection of SwiftUI views to display the results 2D and 3D L-systems that you create with the `Lindenmayer` library.
 
 ## Overview
 

--- a/Sources/LindenmayerViews/Lsystem2DView.swift
+++ b/Sources/LindenmayerViews/Lsystem2DView.swift
@@ -1,6 +1,6 @@
 //
 //  Lsystem2DView.swift
-//  X5336
+//
 //
 //  Created by Joseph Heck on 12/12/21.
 //
@@ -8,27 +8,33 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that provides a 2D rendering of the L-system provide, and optionally metrics associated with the L-system.
 @available(macOS 12.0, iOS 15.0, *)
 public struct Lsystem2DView: View {
+    let displayMetrics: Bool
     let system: LSystem
     let renderer = GraphicsContextRenderer()
     public var body: some View {
         VStack {
-            LSystemMetrics(system: system)
+            if displayMetrics {
+                LSystemMetrics(system: system)
+            }
             Canvas { context, size in
                 renderer.draw(system, into: &context, ofSize: size)
             }
         }
     }
 
-    public init(system: LSystem) {
+    public init(system: LSystem, displayMetrics: Bool = false) {
         self.system = system
+        self.displayMetrics = displayMetrics
     }
 }
 
 @available(macOS 12.0, iOS 15.0, *)
 struct Lsystem2DView_Previews: PreviewProvider {
     static var previews: some View {
-        Lsystem2DView(system: Examples2D.barnsleyFern.lsystem.evolved(iterations: 4))
+        Lsystem2DView(system: Examples2D.barnsleyFern.lsystem.evolved(iterations: 4),
+                      displayMetrics: true)
     }
 }

--- a/Sources/LindenmayerViews/Lsystem3DView.swift
+++ b/Sources/LindenmayerViews/Lsystem3DView.swift
@@ -1,6 +1,6 @@
 //
 //  LSystem3DView.swift
-//  X5336
+//  
 //
 //  Created by Joseph Heck on 12/18/21.
 //
@@ -9,7 +9,9 @@ import Lindenmayer
 import SceneKit
 import SwiftUI
 
+/// A view that provides a 3D rendering of the L-system provide, and optionally metrics associated with the L-system.
 public struct Lsystem3DView: View {
+    let displayMetrics: Bool
     let system: LSystem
     func generateScene() -> SCNScene {
         let x = SceneKitRenderer()
@@ -18,7 +20,9 @@ public struct Lsystem3DView: View {
 
     public var body: some View {
         VStack {
-            LSystemMetrics(system: system)
+            if (displayMetrics) {
+                LSystemMetrics(system: system)
+            }
             SceneView(
                 scene: generateScene(),
                 // pointOfView: generateScene().rootNode.childNode(withName: "camera", recursively: false),
@@ -44,13 +48,15 @@ public struct Lsystem3DView: View {
         }
     }
 
-    public init(system: LSystem) {
+    public init(system: LSystem, displayMetrics: Bool = false) {
+        self.displayMetrics = displayMetrics
         self.system = system
     }
 }
 
 struct Lsystem3DView_Previews: PreviewProvider {
     static var previews: some View {
-        Lsystem3DView(system: Examples3D.algae3D.lsystem.evolved(iterations: 3))
+        Lsystem3DView(system: Examples3D.algae3D.lsystem.evolved(iterations: 3),
+                      displayMetrics: true)
     }
 }

--- a/Sources/LindenmayerViews/Lsystem3DView.swift
+++ b/Sources/LindenmayerViews/Lsystem3DView.swift
@@ -1,6 +1,6 @@
 //
 //  LSystem3DView.swift
-//  
+//
 //
 //  Created by Joseph Heck on 12/18/21.
 //
@@ -20,7 +20,7 @@ public struct Lsystem3DView: View {
 
     public var body: some View {
         VStack {
-            if (displayMetrics) {
+            if displayMetrics {
                 LSystemMetrics(system: system)
             }
             SceneView(

--- a/Sources/LindenmayerViews/ModuleDetailView.swift
+++ b/Sources/LindenmayerViews/ModuleDetailView.swift
@@ -1,5 +1,5 @@
 //
-//  SwiftUIView.swift
+//  ModuleDetailView.swift
 //
 //
 //  Created by Joseph Heck on 1/10/22.
@@ -7,6 +7,9 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that provides a detailed view of a module.
+///
+/// The parameters (if any) of the module, and their values, as displayed above a string representation of the 3D rendering command associated with the module.
 public struct ModuleDetailView: View {
     let module: DebugModule
     public var body: some View {

--- a/Sources/LindenmayerViews/ModuleSummaryView.swift
+++ b/Sources/LindenmayerViews/ModuleSummaryView.swift
@@ -7,6 +7,7 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that represents a summary view of a single debug module from an L-system at the size you choose.
 @available(macOS 12.0, iOS 15.0, *)
 public struct ModuleSummaryView: View {
     let size: SummarySizes

--- a/Sources/LindenmayerViews/Monopodial4Examples.swift
+++ b/Sources/LindenmayerViews/Monopodial4Examples.swift
@@ -9,6 +9,9 @@ import Lindenmayer
 import SceneKit
 import SwiftUI
 
+/// A view that presents the 4 SceneKit scenes that include example trees with a monopodial structure built in to Lindenmayer.
+///
+/// The set of trees match the examples of figure 2.6 in [The Algorithmic Beauty of Plants](http://algorithmicbotany.org/papers/abop/abop.pdf) on page 56.
 public struct Monopodial4Examples: View {
     let system1: LSystem
     let system2: LSystem

--- a/Sources/LindenmayerViews/RollToVerticalTestView.swift
+++ b/Sources/LindenmayerViews/RollToVerticalTestView.swift
@@ -1,0 +1,181 @@
+//
+//  RollToVerticalTestView.swift
+//  
+//
+//  Created by Joseph Heck on 1/18/22.
+//
+
+import SwiftUI
+import Lindenmayer
+import simd
+import SceneKit
+import SceneKitDebugTools
+
+public struct RollToVerticalTestView: View {
+    let scene: SCNScene
+    let pointSphere0: SCNNode
+//    let pointSphereY: SCNNode
+    let pointSphereZ: SCNNode
+    let cameraNode: SCNNode
+    var selectedNode: SCNNode?
+    @State var calculated_angle: Float = 0.0
+    @State var rotated_vector: simd_float3 = simd_float3(0,0,0)
+    @State var aString: String = ""
+    
+    static var transform_119 = simd_float4x4(
+        simd_float4(-1.1513867, -0.12829041, 2.2153668, 0.0),
+        simd_float4(2.173691, 0.43699712, 1.155033, 0.0),
+        simd_float4(-0.44651538, 2.458165, -0.08971556, 0.0),
+        simd_float4(4.4409075, 13.833499, 8.220964, 1.0)
+    )
+
+    static func generatePointSphere() -> SCNNode {
+        let sphereGeometry = SCNSphere(radius: 0.03)
+        sphereGeometry.segmentCount = 12
+        let m = SCNMaterial()
+        m.diffuse.contents = CGColor(red: 1.0, green: 0, blue: 0, alpha: 1.0)
+        sphereGeometry.materials = [m]
+        return SCNNode(geometry: sphereGeometry)
+    }
+
+    @discardableResult
+    static func pointSphereAtLocation(scene: SCNScene, _ x: Float, _ y: Float, _ z: Float) -> SCNNode {
+        let pointSphere = RollToVerticalTestView.generatePointSphere()
+        pointSphere.simdPosition = simd_float3(x,y,z)
+        pointSphere.simdTransform = matrix_multiply(pointSphere.simdTransform, RollToVerticalTestView.transform_119)
+        scene.rootNode.addChildNode(pointSphere)
+        return pointSphere
+    }
+
+    static func generateLineSegment() -> SCNNode {
+        let linecyl = SCNCylinder(radius: 0.01, height: 1.0)
+        linecyl.radialSegmentCount = 3
+        let m = SCNMaterial()
+        m.diffuse.contents = CGColor(red: 1.0, green: 0, blue: 0, alpha: 1.0)
+        linecyl.materials = [m]
+        return SCNNode(geometry: linecyl)
+    }
+
+    static func generateExampleScene() -> (SCNScene, SCNNode) {
+        let scene = SCNScene()
+        // create and add a camera to the scene
+        let cameraNode = SCNNode()
+        cameraNode.name = "camera"
+        cameraNode.camera = SCNCamera()
+        scene.rootNode.addChildNode(cameraNode)
+
+        // place the camera
+        cameraNode.position = SCNVector3(x: 0, y: 4, z: 5)
+        cameraNode.simdLook(at: simd_float3(x: 0, y: 0, z: 0))
+
+        // set up debug/sizing flooring
+        scene.rootNode.addChildNode(debugFlooring())
+
+        return (scene, cameraNode)
+    }
+
+    func calculateThings() {
+        if let selectedNode = selectedNode {
+            // regenerate calculated angle
+            let rotation_from_heading = selectedNode.simdTransform.rotationTransform
+            let original_heading_up_vector = simd_float3(x: 0, y: 0, z: 1)
+            rotated_vector = simd_normalize(matrix_multiply(original_heading_up_vector, rotation_from_heading))
+            
+            // Then we calculate the between the "rotated up" vector and world-space UP (+Y in SceneKit)
+            // to get the amount of angle we should roll. We're explicitly working with normalized vectors
+            // here to make the calculation of cos-1( a • b / |a| * |b| ) easier. With unit vectors, this
+            // collapses to acos(a • b).
+            calculated_angle = acos(simd_dot(rotated_vector, simd_normalize(simd_float3(0, 1, 0))))
+        }
+    }
+
+    public var body: some View {
+        VStack{
+            HStack {
+                Text("Angle: \(calculated_angle) ( \(Angle(radians: Double(calculated_angle)).degrees)° )")
+                TextField("roll amount", text: $aString)
+                Button {
+                    if let selectedNode = selectedNode {
+                        if let floatValue = Float(aString) {
+                            print("before rotation")
+                            print("\(pointSphereZ.simdTransform.prettyPrintString())")
+                            let rotationTransform = rotationAroundYAxisTransform(angle: floatValue)
+                            selectedNode.simdTransform = matrix_multiply(selectedNode.simdTransform, rotationTransform)
+                            pointSphere0.simdTransform = matrix_multiply(pointSphere0.simdTransform, rotationTransform)
+
+                            pointSphereZ.simdTransform = matrix_multiply(pointSphereZ.simdTransform, rotationTransform)
+//                            pointSphereY.simdTransform = matrix_multiply(pointSphereY.simdTransform, rotationTransform)
+                            print("after rotation")
+                            print("\(pointSphereZ.simdTransform.prettyPrintString())")
+                        }
+                    }
+                    calculateThings()
+                } label: {
+                    Text("Apply Roll")
+                }
+            }
+//            Text("world up vector: \(String(describing: selectedNode?.worldUp))")
+//            Text("world right vector: \(String(describing: selectedNode?.worldRight))")
+//            Text("world front vector: \(String(describing: selectedNode?.worldFront))")
+            Text("rotated vector \(String(describing: rotated_vector))")
+            DebugSceneView(scene: scene, node: selectedNode)
+        }
+        .onAppear {
+            calculateThings()
+        }
+    }
+    
+    public init() {
+        (self.scene, self.cameraNode) = RollToVerticalTestView.generateExampleScene()
+        scene.rootNode.addChildNode(axis(length: 4, labels: true))
+        let heading = headingIndicator()
+        scene.rootNode.addChildNode(heading)
+        heading.simdTransform = RollToVerticalTestView.transform_119
+        self.selectedNode = heading
+        cameraNode.simdLook(at: heading.simdPosition)
+        
+        let zLine = RollToVerticalTestView.generateLineSegment()
+        zLine.simdPosition = simd_float3(0,0,0.5)
+//        let zLineNudge = translationTransform(x: 0, y: 0, z: 0.5)
+//        zLine.simdTransform = matrix_multiply(zLine.simdTransform, zLineNudge)
+        let zLineRotation = rotationAroundXAxisTransform(angle: Float.pi/2)
+        zLine.simdTransform = matrix_multiply(zLine.simdTransform, zLineRotation)
+//        zLine.simdTransform = matrix_multiply(zLine.simdTransform, RollToVerticalTestView.transform_119)
+        scene.rootNode.addChildNode(zLine)
+        
+        pointSphere0 = RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0, 0.25)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0, 0.5)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0, 0.75)
+        pointSphereZ = RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0, 1)
+
+        // X axis points - rotated into place
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0.2, 0, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0.4, 0, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0.6, 0, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0.8, 0, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 1.0, 0, 0)
+
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.1, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.2, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.3, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.4, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.5, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.6, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.7, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.8, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 0.9, 0)
+        RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 1.0, 0)
+//        pointSphereY = RollToVerticalTestView.pointSphereAtLocation(scene: scene, 0, 1, 0)
+
+        scene.rootNode.addChildNode(pointSphere0)
+        scene.rootNode.addChildNode(pointSphereZ)
+//        scene.rootNode.addChildNode(pointSphereY)
+    }
+}
+
+struct RollToVerticalTestView_Previews: PreviewProvider {
+    static var previews: some View {
+        RollToVerticalTestView()
+    }
+}

--- a/Sources/LindenmayerViews/StateSelectorView.swift
+++ b/Sources/LindenmayerViews/StateSelectorView.swift
@@ -8,6 +8,7 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that provides a visual representation of the states of an L-system and allows the person viewing it to select an index position from that L-system's state.
 @available(macOS 12.0, iOS 15.0, *)
 public struct StateSelectorView: View {
     let system: LSystem
@@ -27,7 +28,7 @@ public struct StateSelectorView: View {
         VStack {
             ScrollViewReader { proxy in
                 ScrollView(.horizontal, showsIndicators: true) {
-                    HorizontalSummarySequence(size: .medium, system: system)
+                    HorizontalLSystemStateView(size: .medium, system: system)
                 }
                 if system.state.count > 1 {
                     // a slider can't be 0 ... 0 - "max stride must be positive"

--- a/Sources/LindenmayerViews/Sympodial4Examples.swift
+++ b/Sources/LindenmayerViews/Sympodial4Examples.swift
@@ -9,6 +9,9 @@ import Lindenmayer
 import SceneKit
 import SwiftUI
 
+/// A view that presents the 4 SceneKit scenes that include example trees with a sympodial structure built in to Lindenmayer.
+///
+/// The set of trees match the example in figure 2.7 of [The Algorithmic Beauty of Plants](http://algorithmicbotany.org/papers/abop/abop.pdf) on page 59.
 public struct Sympodial4Examples: View {
     let system1: LSystem
     let system2: LSystem

--- a/Sources/LindenmayerViews/WindowedSmallModuleView.swift
+++ b/Sources/LindenmayerViews/WindowedSmallModuleView.swift
@@ -1,5 +1,5 @@
 //
-//  SwiftUIView.swift
+//  WindowedSmallModuleView.swift
 //
 //
 //  Created by Joseph Heck on 1/10/22.
@@ -8,6 +8,9 @@
 import Lindenmayer
 import SwiftUI
 
+/// A view that displays a window of a set of modules at the index location and window size that you choose for the L-system you provide.
+///
+/// The window sizes supported ranges from `1` to `9`.
 @available(macOS 12.0, iOS 15.0, *)
 public struct WindowedSmallModuleView: View {
     let size: SummarySizes

--- a/Tests/LindenmayerTests/RollUpToVerticalTests.swift
+++ b/Tests/LindenmayerTests/RollUpToVerticalTests.swift
@@ -1,0 +1,214 @@
+//
+//  RollUpToVerticalTests.swift
+//  
+//
+//  Created by Joseph Heck on 1/18/22.
+//
+
+import Lindenmayer
+import SceneKit
+import SwiftUI // for `Angle`
+import simd
+import XCTest
+
+final class RollUpToVerticalTests: XCTestCase {
+
+    // NOTE(heckj): When transcribing a 4x4 matrix, the initializer uses
+    // 'COLUMNS', not rows - so create simd_float4x4 matrices by vertical columns:
+    // top to bottom, left to right.
+    static var transform_119 = simd_float4x4(
+        simd_float4(-1.1513867, -0.12829041, 2.2153668, 0.0),
+        simd_float4(2.173691, 0.43699712, 1.155033, 0.0),
+        simd_float4(-0.44651538, 2.458165, -0.08971556, 0.0),
+        simd_float4(4.4409075, 13.833499, 8.220964, 1.0)
+    )
+
+    func testMatchingEulerAngles() throws {
+        let node = SCNNode()
+        node.simdTransform = RollUpToVerticalTests.transform_119
+        XCTAssertEqual(node.simdEulerAngles.x, 1.648, accuracy: 0.001) // pitch
+        XCTAssertEqual(node.simdEulerAngles.y, -1.089, accuracy: 0.001) // yaw
+        XCTAssertEqual(node.simdEulerAngles.z, -3.031, accuracy: 0.001) // roll
+    }
+
+    func testApplyingAffineTransformsToA3DPoint() throws {
+        let pt = simd_float4(0, 0, 1, 1) // x=0, y=0, z=1
+        let result = matrix_multiply(RollUpToVerticalTests.transform_119, pt)
+        let result2 = matrix_multiply(pt, RollUpToVerticalTests.transform_119)
+        // ORDER MATTERS!!
+        XCTAssertNotEqual(result, result2)
+        print(result)
+        
+//        print("[0,0,0] through translations: \(matrix_multiply(RollUpToVerticalTests.transform_119, simd_float4(0,0,0,1)))")
+//        print("[0,0,1] through translations: \(matrix_multiply(RollUpToVerticalTests.transform_119, simd_float4(0,0,1,1)))")
+//        print("[1,0,0] through translations: \(matrix_multiply(RollUpToVerticalTests.transform_119, simd_float4(1,0,0,1)))")
+                
+        // This insanity is just verifying for myself that I can legit pull out the rotation transform from the
+        // 4x4 3D affine transform matrix and use it to get a correct rotation applying it directly to a 1x3 float vector.
+        let pt3 = simd_float3(0,0,1)
+        let rotation_matrix_3x3 = RollUpToVerticalTests.transform_119.rotationTransform
+        let result3 = matrix_multiply(rotation_matrix_3x3, pt3)
+        
+        XCTAssertEqual(result3.x, result.x - RollUpToVerticalTests.transform_119.columns.3.x, accuracy: 0.00001)
+        XCTAssertEqual(result3.y, result.y - RollUpToVerticalTests.transform_119.columns.3.y, accuracy: 0.0001)
+        XCTAssertEqual(result3.z, result.z - RollUpToVerticalTests.transform_119.columns.3.z, accuracy: 0.001)
+    }
+
+    func testApplyingKnownTransformsToA3DPoint() throws {
+        let pt = simd_float3(0, 0, 1) // x=0, y=0, z=1
+        let rotate_90_around_Y = rotationAroundYAxisTransform(angle: Float.pi/2).rotationTransform
+        
+        // DUH tests - identity should be equivalent in either direction
+        XCTAssertEqual(matrix_multiply(matrix_identity_float3x3, pt), pt)
+        XCTAssertEqual(matrix_multiply(pt, matrix_identity_float3x3), pt)
+        
+        let rotation_first_result = matrix_multiply(rotate_90_around_Y, pt)
+        let point_first_result = matrix_multiply(pt, rotate_90_around_Y)
+        // ORDER MATTERS!! - result should be +1 in the X direction
+        // which means the matrix calculation with the transform first, then the
+        // point we're transforming, is correct.
+        XCTAssertNotEqual(rotation_first_result, point_first_result)
+        print(rotation_first_result)
+        XCTAssertEqual(rotation_first_result.x, 1, accuracy: 0.00001)
+        XCTAssertEqual(rotation_first_result.y, 0, accuracy: 0.00001)
+        XCTAssertEqual(rotation_first_result.z, 0, accuracy: 0.00001)
+
+        // Doing this in the reverse order gives you a vector in the opposite direction
+        print(point_first_result)
+        XCTAssertEqual(point_first_result.x, -1, accuracy: 0.00001)
+        XCTAssertEqual(rotation_first_result.y, 0, accuracy: 0.00001)
+        XCTAssertEqual(rotation_first_result.z, 0, accuracy: 0.00001)
+    }
+    
+    func testRotatingIdentityMatrix() throws {
+        // Identity state vector indicates we've not moved from start, so the forward vector is +Y and the
+        // up vector is +Z. No amount of rotation will do us any good, since the plane we're rotating on (the X-Z plane)
+        // can't get any closer to +Y.
+        let rotation_on_XZ_plane = try rotationToVerticalTestCode(matrix_identity_float4x4)
+        XCTAssertEqual(0, rotation_on_XZ_plane)
+    }
+
+    func testRotating45degToRightMatrix() throws {
+        // This rotation is a "right turn" from the starting position, straight up. We rotation 45° around
+        // the Z axis - negative rotation to make it to the right.
+        // The resulting rotation plane is tilted 45° to the right as well, so should result in a rotation
+        // of -90° on that plane to get the "up" vector as close to +Y as possible.
+        let state_transform = matrix_multiply(matrix_identity_float4x4, rotationAroundZAxisTransform(angle: -Float.pi/4))
+        let rotation_on_plane = try rotationToVerticalTestCode(state_transform)
+        XCTAssertEqual(-Float.pi/2, rotation_on_plane, accuracy: 0.0001)
+    }
+
+    func testRotating45degToLeftMatrix() throws {
+        // This rotation is a "right turn" from the starting position, straight up. We rotation 45° around
+        // the Z axis - negative rotation to make it to the right.
+        // The resulting rotation plane is tilted 45° to the right as well, so should result in a rotation
+        // of -90° on that plane to get the "up" vector as close to +Y as possible.
+        let state_transform = matrix_multiply(matrix_identity_float4x4, rotationAroundZAxisTransform(angle: Float.pi/4))
+        let rotation_on_plane = try rotationToVerticalTestCode(state_transform)
+        XCTAssertEqual(Float.pi/2, rotation_on_plane, accuracy: 0.0001)
+    }
+
+    func testRotating45degPitchUpMatrix() throws {
+        // This rotation is a "pitch up" from the starting position, straight up. We rotate 45° around
+        // the X axis - negative rotation to make it pitch 'up'.
+        // The resulting rotation plane is tilted 45° up towards -Z, so should result in a rotation
+        // of 180° on that plane to get the "up" vector as close to +Y as possible.
+        let state_transform = matrix_multiply(matrix_identity_float4x4, rotationAroundXAxisTransform(angle: -Float.pi/4))
+        let rotation_on_plane = try rotationToVerticalTestCode(state_transform)
+        XCTAssertEqual(Float.pi, rotation_on_plane, accuracy: 0.0001)
+    }
+
+    func testRotating45degPitchDownMatrix() throws {
+        // This rotation is a "pitch down" from the starting position, straight up. We rotate 45° around
+        // the X axis - positive rotation to make it to pitch 'down'.
+        // The resulting rotation plane is tilted 45° up towards the +z, so should result in a rotation
+        // of 0° on that plane to get the "up" vector as close to +Y as possible.
+        let state_transform = matrix_multiply(matrix_identity_float4x4, rotationAroundXAxisTransform(angle: Float.pi/4))
+        let rotation_on_plane = try rotationToVerticalTestCode(state_transform)
+        XCTAssertEqual(0, rotation_on_plane, accuracy: 0.0001)
+    }
+
+    func testRotating90degPitchUpMatrix() throws {
+        // Since we start facing straight up, pitching up another 90° results in us facing the +z direction
+        // with the "up" vector now rotated to point pretty much straight in the -Y direction.
+        let state_transform = matrix_multiply(matrix_identity_float4x4, rotationAroundXAxisTransform(angle: Float.pi/2))
+        let rotation_on_plane = try rotationToVerticalTestCode(state_transform)
+        XCTAssertEqual(Float.pi, rotation_on_plane, accuracy: 0.0001)
+    }
+
+    func rotationToVerticalTestCode(_ full_transform: simd_float4x4) throws -> Float {
+        // The interpretation of this symbol is a tricky beast. From pg 41 of
+        // http://algorithmicbotany.org/papers/hanan.dis1992.pdf
+        // 'PARAMETRIC L-SYSTEMS AND THEIR APPLICATION TO THE MODELLING AND VISUALIZATION OF PLANTS'
+        //
+        // @V rotates the turtle around it's heading vector so that the left vector is horizontal and the y component of the up vector is positive.
+        // The initial heading of the 3D turtle vector is "upward" (in the +Y direction in SceneKit),
+        // and the "up vector" relative to that heading is a unit-vector in the +Z direction.
+        // The intention of this symbol is to take the rotation around the axis of the heading (whatever
+        // the +Y unit vector has been rotated to), and rotate/roll around that vector so that the
+        // "up" direction is as close to vertical in the world-space as possible.
+        
+        // We implement this by pulling out just the rotation portion of the transform from the
+        // current world transform and applying that to the original "up" vector to get the up vector
+        // rotated to match the current state of the heading.
+        let original_heading_up_vector = simd_float3(x: 0, y: 0, z: 1)
+        let north_pole_vector = simd_float3(x: 0,y: 1,z: 0)
+        let rotated_up_vector = matrix_multiply(full_transform.rotationTransform, original_heading_up_vector)
+        print("rotated up vector: \(rotated_up_vector), length: \(simd_length(rotated_up_vector))")
+        
+        // Now we need to project this onto the rotated X,Z plane - which is most conveniently defined
+        // as the normal vector from that plane - otherwise known as our heading vector.
+        let heading_vector = full_transform.headingVector()
+        print("heading vector: \(heading_vector), length: \(simd_length(heading_vector))")
+        
+        // These two vector should be 90° difference from each other, so let's double check that by
+        // computing the angle between the rotated heading and rotated up vectors:
+        let double_check_angle = acos(
+            simd_dot(heading_vector, rotated_up_vector) /
+            ( simd_length(heading_vector) * simd_length(rotated_up_vector) )
+        )
+        XCTAssertEqual(Float.pi/2, double_check_angle, accuracy: 0.00001)
+        
+        // Now we need to project the world +y Vector onto the plane represented by the heading vector
+        // as a normal to that plane. The resulting vector will be limited to that plane, and that's what
+        // we can use to compare the angle to the rotated up vector, which is also on that plane, as we
+        // just verified.
+        
+        // The formula for projecting a vector onto a plane:
+        // vec_projected = vector - ( ( vector • plane_normal ) / plane_normal.length^2 ) * plane_normal
+        // You can look at this conceptually as taking the vector you want to project and subtracting from it
+        // the portion of the vector that corresponds to the normal vector, which leaves you with just the
+        // component that's aligned on the plane.
+        // 🎩 to Greg Titus, who referred me to https://www.maplesoft.com/support/help/maple/view.aspx?path=MathApps%2FProjectionOfVectorOntoPlane
+        
+        print("+Y • plane-normal = \(simd_dot(north_pole_vector, heading_vector))")
+        
+        let component_of_normal = ( simd_dot(north_pole_vector, heading_vector) / simd_length_squared(heading_vector) ) * heading_vector
+        print("component along normal vector: \(component_of_normal), length: \(simd_length(component_of_normal))")
+        let projected_vector = north_pole_vector - component_of_normal
+        print("projected vector onto plane: \(projected_vector), length: \(simd_length(projected_vector))")
+        
+        // Finally, we calculate the angle between this projected vector and the world-space UP (+Y in SceneKit)
+        // vector to get the angle we'll want to roll to make everything "aligned" as closely as possible.
+        // It's worth noting that if the projected vector is really small, this might be a little insane.
+        // That means that the plane around which we're rotating is nearly perfectly aligned with the
+        // world's X-Z coordinate plane, and there's just no rotation that makes a difference. Fortunately, as
+        // the value trends to 0, then the value of acos(θ) tends to 0 as well - so at least this is numerically stable.
+        //
+        // acos(1.0) => 0
+        // acos(0.5) => 60° (1.0471976)
+        // acos(0.0) => 90° (1.5707963)
+        
+        print("projected_vector • rotated_up_vector = \(simd_dot(projected_vector, rotated_up_vector))")
+        let resulting_angle = acos(
+            simd_dot(rotated_up_vector, projected_vector) /
+            ( simd_length(projected_vector) * simd_length(rotated_up_vector) )
+        )
+
+        // I think I need to determine a +/- value to this rotation, as the angle isn't signed - it's not directional.
+        print("And the resulting angle: \(resulting_angle) (\(Angle(radians: Double(resulting_angle)).degrees)°)")
+        return resulting_angle
+    }
+
+}
+

--- a/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
@@ -20,7 +20,7 @@ final class WhiteboxParametricRuleTests: XCTestCase {
     let p = ParameterizedExample()
 
     func testRuleDefaults() throws {
-        let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self, parameters: PWrapper(ExampleDefines()), prng: RNGWrapper(PRNG(seed: 0)), where: nil) { _, p, _ -> [Module] in
+        let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self, parameters: ParametersWrapper(ExampleDefines()), prng: RNGWrapper(PRNG(seed: 0)), where: nil) { _, p, _ -> [Module] in
             [ParameterizedExample(p.value + 1.0)]
         }
 
@@ -44,7 +44,7 @@ final class WhiteboxParametricRuleTests: XCTestCase {
 
     func testRuleDefaultsWithSystemParameters() throws {
         let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self,
-                                            parameters: PWrapper(ExampleDefines()),
+                                            parameters: ParametersWrapper(ExampleDefines()),
                                             prng: RNGWrapper(PRNG(seed: 0)),
                                             where: nil) { _, p, _ -> [Module] in
             [ParameterizedExample(p.value + p.value)]


### PR DESCRIPTION
resolves #7 

- reset the process flow and extracted the code and equations
- switched the process to forward project into the rotated space for vector evaluation
- explicitly projected the vector instead evaluating the angle between +Y and the rotated UP vector
- added simple tests to verify the rotation is as expected for no translation and tilting 45° in each coordinate direction