### PR TITLE
removing Squirrel3 dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,12 +18,6 @@ let package = Package(
         .library(name: "LindenmayerViews", targets: ["LindenmayerViews"]),
     ],
     dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-        .package(
-            name: "Squirrel3",
-            url: "https://github.com/heckj/Squirrel3.git", .upToNextMajor(from: "1.1.0")
-        ),
         .package(
             name: "SceneKitDebugTools",
             url: "https://github.com/heckj/SceneKitDebugTools.git", .upToNextMajor(from: "0.1.0")
@@ -32,7 +26,7 @@ let package = Package(
     targets: [
         .target(
             name: "Lindenmayer",
-            dependencies: ["Squirrel3", "SceneKitDebugTools"]
+            dependencies: ["SceneKitDebugTools"]
         ),
         .target(
             name: "LindenmayerViews",
@@ -40,7 +34,7 @@ let package = Package(
         ),
         .testTarget(
             name: "LindenmayerTests",
-            dependencies: ["Lindenmayer", "Squirrel3", "SceneKitDebugTools"]
+            dependencies: ["Lindenmayer", "SceneKitDebugTools"]
         ),
     ]
 )

--- a/Sources/Lindenmayer/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples3D.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A collection of three-dimensional example L-systems.
 ///
@@ -221,7 +220,7 @@ public enum Examples3D {
     /// The example source for this L-system is [available on GitHub](https://github.com/heckj/Lindenmayer/blob/main/Sources/Lindenmayer/Examples3D.swift).
     public static var monopodialTree = LSystem.create(
         [Trunk(growthDistance: defines.trunklength, diameter: defines.trunkdiameter)],
-        with: PRNG(seed: 42),
+        with: Xoshiro(seed: 42),
         using: defines
     )
     .rewriteWithParams(directContext: Trunk.self) { trunk, params in
@@ -352,7 +351,7 @@ public enum Examples3D {
     /// The example source for this L-system is [available on GitHub](https://github.com/heckj/Lindenmayer/blob/main/Sources/Lindenmayer/Examples3D.swift).
     public static let sympodialTree = LSystem.create(
         MainBranch(growthDistance: 10, diameter: 1),
-        with: PRNG(seed: 0),
+        with: Xoshiro(seed: 0),
         using: figure2_7A
     ).rewriteWithParams(directContext: MainBranch.self) { node, params in
         //    p1 : A(l,w) : * → !(w)F(l)[&(a1)B(l*r1,w*wr)] /(180)[&(a2 )B(l*r2 ,w*wr )]
@@ -415,7 +414,7 @@ public enum Examples3D {
         }
     }
 
-    public static var randomBush = LSystem.create(Stem2(length: 1), with: PRNG(seed: 42))
+    public static var randomBush = LSystem.create(Stem2(length: 1), with: Xoshiro(seed: 42))
         .rewriteWithRNG(directContext: Stem2.self) { stem, rng -> [Module] in
 
             let upper: Float = 45.0

--- a/Sources/Lindenmayer/LSystem.swift
+++ b/Sources/Lindenmayer/LSystem.swift
@@ -28,13 +28,13 @@ import Foundation
 ///
 /// ### Creating a Contextual L-system with Randomness
 ///
-/// - ``LSystem/create(_:with:)-8xbbx``
-/// - ``LSystem/create(_:with:)-1otrb``
+/// - ``Lindenmayer/LSystem/create(_:with:)-5qbah``
+/// - ``Lindenmayer/LSystem/create(_:with:)-9349q``
 ///
 /// ### Creating a Contextual L-system with Randomness and Parameters
 ///
-/// - ``LSystem/create(_:with:using:)-49uk9``
-/// - ``LSystem/create(_:with:using:)-49uk9``
+/// - ``Lindenmayer/LSystem/create(_:with:using:)-1nce9``
+/// - ``Lindenmayer/LSystem/create(_:with:using:)-2nwqc``
 ///
 public enum LSystem {
     /// Creates a new Lindenmayer system from an initial state.

--- a/Sources/Lindenmayer/LSystem.swift
+++ b/Sources/Lindenmayer/LSystem.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A type that provides convenient initializers for L-systems.
 ///
@@ -60,7 +59,7 @@ public enum LSystem {
         if let prng = prng {
             return RandomContextualLSystem(axiom: [axiom], state: nil, newStateIndicators: nil, prng: RNGWrapper(prng))
         }
-        return RandomContextualLSystem(axiom: [axiom], state: nil, newStateIndicators: nil, prng: RNGWrapper(PRNG(seed: 42) as! RNGType))
+        return RandomContextualLSystem(axiom: [axiom], state: nil, newStateIndicators: nil, prng: RNGWrapper(Xoshiro(seed: 42) as! RNGType))
     }
 
     /// Creates a new Lindenmayer system from an initial state and using the random number generator you provide..
@@ -71,7 +70,7 @@ public enum LSystem {
         if let prng = prng {
             return RandomContextualLSystem(axiom: axiom, state: nil, newStateIndicators: nil, prng: RNGWrapper(prng))
         }
-        return RandomContextualLSystem(axiom: axiom, state: nil, newStateIndicators: nil, prng: RNGWrapper(PRNG(seed: 42) as! RNGType))
+        return RandomContextualLSystem(axiom: axiom, state: nil, newStateIndicators: nil, prng: RNGWrapper(Xoshiro(seed: 42) as! RNGType))
     }
 
     /// Creates a new Lindenmayer system from an initial state, using the random number generator and parameter instance that you provide.
@@ -83,7 +82,7 @@ public enum LSystem {
         if let prng = prng {
             return ParameterizedRandomContextualLSystem(axiom: [axiom], state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(prng), rules: [])
         }
-        return ParameterizedRandomContextualLSystem(axiom: [axiom], state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(PRNG(seed: 42) as! RNGType), rules: [])
+        return ParameterizedRandomContextualLSystem(axiom: [axiom], state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(Xoshiro(seed: 42) as! RNGType), rules: [])
     }
 
     /// Creates a new Lindenmayer system from an initial state, using the random number generator and parameter instance that you provide.
@@ -95,6 +94,6 @@ public enum LSystem {
         if let prng = prng {
             return ParameterizedRandomContextualLSystem(axiom: axiom, state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(prng), rules: [])
         }
-        return ParameterizedRandomContextualLSystem(axiom: axiom, state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(PRNG(seed: 42) as! RNGType), rules: [])
+        return ParameterizedRandomContextualLSystem(axiom: axiom, state: nil, newStateIndicators: nil, parameters: ParametersWrapper(parameters), prng: RNGWrapper(Xoshiro(seed: 42) as! RNGType), rules: [])
     }
 }

--- a/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
+++ b/Sources/Lindenmayer/Lindenmayer.docc/Lindenmayer.md
@@ -28,7 +28,6 @@ To get support for using this package, see the [Discussions on Github](https://g
 - ``ParameterizedRandomContextualLSystem``
 - ``LindenmayerSystem``
 - ``ModuleSet``
-- ``RNGWrapper``
 - ``ParametersWrapper``
 
 ### Modules
@@ -85,3 +84,9 @@ To get support for using this package, see the [Discussions on Github](https://g
 
 - ``Examples2D``
 - ``Examples3D``
+
+### Seeded Pseudo-Random Number Generation
+
+- ``RNGWrapper``
+- ``Lindenmayer/SeededRandomNumberGenerator``
+- ``Lindenmayer/Xoshiro``

--- a/Sources/Lindenmayer/ParameterizedRandomContextualLSystem.swift
+++ b/Sources/Lindenmayer/ParameterizedRandomContextualLSystem.swift
@@ -112,7 +112,7 @@ public struct ParameterizedRandomContextualLSystem<PType, PRNG>: LindenmayerSyst
     ///   - prng: A psuedo-random number generator to use for stochastic rule productions.
     ///   - rules: A collection of rules that the Lindenmayer system applies when you call the evolve function.
     ///
-    /// Convenient initializers for creating contextual L-systems uses ``LSystem``, calling ``LSystem/create(_:with:using:)-30rc3``, or ``LSystem/create(_:with:using:)-49uk9``.
+    /// Convenient initializers for creating contextual L-systems uses ``LSystem``, calling ``Lindenmayer/LSystem/create(_:with:using:)-1nce9``, or ``Lindenmayer/LSystem/create(_:with:using:)-2nwqc``
     public init(axiom: [Module],
                 state: [Module]?,
                 newStateIndicators: [Bool]?,

--- a/Sources/Lindenmayer/ParameterizedRandomContextualLSystem.swift
+++ b/Sources/Lindenmayer/ParameterizedRandomContextualLSystem.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A parameterized, stochastic Lindenmayer system.
 ///

--- a/Sources/Lindenmayer/ParametersWrapper.swift
+++ b/Sources/Lindenmayer/ParametersWrapper.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A class that provides reference semantics to access an underlying parameter value type that you provide.
 ///

--- a/Sources/Lindenmayer/RNGWrapper.swift
+++ b/Sources/Lindenmayer/RNGWrapper.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A class that provides probabilistic functions based on the seedable psuedo-random number generator used to create it.
 ///

--- a/Sources/Lindenmayer/RandomContextualLSystem.swift
+++ b/Sources/Lindenmayer/RandomContextualLSystem.swift
@@ -90,7 +90,8 @@ public struct RandomContextualLSystem<PRNG>: LindenmayerSystem where PRNG: Seede
     ///   - prng: A psuedo-random number generator to use for stochastic rule productions.
     ///   - rules: A collection of rules that the Lindenmayer system applies when you call the evolve function.
     ///
-    /// Convenient initializers for creating contextual L-systems uses ``LSystem``, calling ``LSystem/create(_:with:)-1otrb``, or ``LSystem/create(_:with:)-1otrb``.
+    /// Convenient initializers for creating contextual L-systems uses ``LSystem``,
+    /// calling ``Lindenmayer/LSystem/create(_:with:using:)-1nce9``, or ``Lindenmayer/LSystem/create(_:with:using:)-2nwqc``.
     public init(axiom: [Module],
                 state: [Module]?,
                 newStateIndicators: [Bool]?,

--- a/Sources/Lindenmayer/RandomContextualLSystem.swift
+++ b/Sources/Lindenmayer/RandomContextualLSystem.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A stochastic Lindenmayer system.
 ///

--- a/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectDefinesRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/RewriteRuleDirectRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightDefinesRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/RewriteRuleDirectRightRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleDirectRightRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectDefinesRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightDefinesRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/RewriteRuleLeftDirectRightRNG.swift
+++ b/Sources/Lindenmayer/RewriteRuleLeftDirectRightRNG.swift
@@ -6,7 +6,6 @@
 //
 
 import Foundation
-import Squirrel3
 
 /// A rule represents a potential re-writing match to elements within the L-systems state and the closure that provides the elements to be used for the new state elements.
 ///

--- a/Sources/Lindenmayer/SeededRandomNumberGenerator.swift
+++ b/Sources/Lindenmayer/SeededRandomNumberGenerator.swift
@@ -1,0 +1,23 @@
+//
+//  SeededRandomNumberGenerator.swift
+//
+//  Created by Joseph Heck on 1/1/22.
+//
+
+import Foundation
+
+/// A type that represents a random number generator that you can seed.
+///
+/// The protocol includes an adjustable position property that represents the current location within the space of random numbers that the random number generates.
+/// The seed value is preserved and unchanged, allowing the seeded random number generator to be interrogated and replicated.
+/// When applied to a pseudo-random number generator, with a given seed and position, the next random number should be  completely deterministic.
+public protocol SeededRandomNumberGenerator: RandomNumberGenerator {
+    /// The seed for the random number generator.
+    var seed: UInt64 { get }
+
+    /// An adjustable position from which influences the next random value that the seed generates.
+    var position: UInt64 { get set }
+
+    /// Creates a new pseudo-random number generator with the seed you provide.
+    init(seed: UInt64)
+}

--- a/Sources/Lindenmayer/Xoshiro.swift
+++ b/Sources/Lindenmayer/Xoshiro.swift
@@ -16,20 +16,28 @@
 //    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
 //    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
+/// A pseudo-random number generator that produces random numbers based on an initial seed.
+///
+/// The algorithm for the generation is xoshiro256, based on the [public domain implementation](http://xoshiro.di.unimi.it).
 public struct Xoshiro: SeededRandomNumberGenerator {
+    /// The initial seed for pseuo-random number generation.
     public let seed: UInt64
-
+    
+    /// The current position of the generator.
     public var position: UInt64
 
     public typealias StateType = (UInt64, UInt64, UInt64, UInt64)
     private var state: StateType = (0, 0, 0, 0)
-
+    
+    /// Creates a new pseudo-random number generator from the seed value you provide.
+    /// - Parameter seed: A seed value.
     public init(seed: UInt64) {
         self.seed = seed
         position = 0
         state = (seed, seed, seed, seed)
     }
-
+    
+    /// Returns the next pseudo-random number.
     public mutating func next() -> UInt64 {
         /*  Written in 2016 by David Blackman and Sebastiano Vigna (vigna@acm.org)
 

--- a/Sources/Lindenmayer/Xoshiro.swift
+++ b/Sources/Lindenmayer/Xoshiro.swift
@@ -1,0 +1,59 @@
+
+// Adopted from https://github.com/mattgallagher/CwlUtils/blob/0bfc4587d01cfc796b6c7e118fc631333dd8ab33/Sources/CwlUtils/CwlRandom.swift
+//    ISC License
+//
+//    Copyright © 2017 Matt Gallagher ( http://cocoawithlove.com ). All rights reserved.
+//
+//    Permission to use, copy, modify, and/or distribute this software for any
+//    purpose with or without fee is hereby granted, provided that the above
+//    copyright notice and this permission notice appear in all copies.
+//
+//    THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+//    WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+//    MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+//    SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+//    WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+//    ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+//    IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+public struct Xoshiro: SeededRandomNumberGenerator {
+    public let seed: UInt64
+
+    public var position: UInt64
+
+    public typealias StateType = (UInt64, UInt64, UInt64, UInt64)
+    private var state: StateType = (0, 0, 0, 0)
+
+    public init(seed: UInt64) {
+        self.seed = seed
+        position = 0
+        state = (seed, seed, seed, seed)
+    }
+
+    public mutating func next() -> UInt64 {
+        /*  Written in 2016 by David Blackman and Sebastiano Vigna (vigna@acm.org)
+
+         To the extent possible under law, the author has dedicated all copyright
+         and related and neighboring rights to this software to the public domain
+         worldwide. This software is distributed without any warranty.
+
+         See <http://creativecommons.org/publicdomain/zero/1.0/>.
+         shima-u.ac.jp (remove spaces)
+         */
+
+        // Derived from public domain implementation of xoshiro256** here:
+        // http://xoshiro.di.unimi.it
+        // by David Blackman and Sebastiano Vigna
+        let x = state.1 &* 5
+        let result = ((x &<< 7) | (x &>> 57)) &* 9
+        let t = state.1 &<< 17
+        state.2 ^= state.0
+        state.3 ^= state.1
+        state.1 ^= state.2
+        state.0 ^= state.3
+        state.2 ^= t
+        state.3 = (state.3 &<< 45) | (state.3 &>> 19)
+        position += 1
+        return result
+    }
+}

--- a/Sources/LindenmayerViews/LindenmayerViews.docc/LindenmayerViews.md
+++ b/Sources/LindenmayerViews/LindenmayerViews.docc/LindenmayerViews.md
@@ -4,6 +4,36 @@ LindenmayerViews provides a collection of SwiftUI views to display the results 2
 
 ## Overview
 
-
-
 ## Topics
+
+### Example Views
+
+- ``LindenmayerViews/Monopodial4Examples``
+- ``LindenmayerViews/Sympodial4Examples``
+
+### 2D View Components
+
+- ``LindenmayerViews/Lsystem2DView``
+- ``LindenmayerViews/Dynamic2DLSystemViews``
+
+### 3D View Components
+
+- ``LindenmayerViews/Lsystem3DView``
+- ``LindenmayerViews/LSystem3DControlView``
+- ``LindenmayerViews/LSystem3DModel``
+
+### General View Components
+
+- ``LindenmayerViews/HorizontalLSystemStateView``
+- ``LindenmayerViews/LSystemMetrics``
+- ``LindenmayerViews/ModuleDetailView``
+- ``LindenmayerViews/ModuleSummaryView``
+- ``LindenmayerViews/EmptyModuleSummaryView``
+- ``LindenmayerViews/StateSelectorView``
+- ``LindenmayerViews/WindowedSmallModuleView``
+- ``LindenmayerViews/SummarySizes``
+
+### Debugging Views
+
+- ``LindenmayerViews/RollToVerticalTestView``
+

--- a/Tests/LindenmayerTests/LSystemTests.swift
+++ b/Tests/LindenmayerTests/LSystemTests.swift
@@ -1,10 +1,9 @@
 @testable import Lindenmayer
-import Squirrel3
 import XCTest
 
 final class LSystemTests: XCTestCase {
     func testLSystemDefault() throws {
-        let x = RandomContextualLSystem<PRNG>(axiom: [Examples2D.Internode()], state: nil, newStateIndicators: nil, prng: RNGWrapper(PRNG(seed: 0)))
+        let x = RandomContextualLSystem(axiom: [Examples2D.Internode()], state: nil, newStateIndicators: nil, prng: RNGWrapper(Xoshiro(seed: 0)))
         XCTAssertNotNil(x)
 
         let result = x.state

--- a/Tests/LindenmayerTests/PRNGWrapperTests.swift
+++ b/Tests/LindenmayerTests/PRNGWrapperTests.swift
@@ -1,18 +1,17 @@
 @testable import Lindenmayer
-import Squirrel3
 import XCTest
 
 final class PRNGWrapperTests: XCTestCase {
     func testConsistency_HasherPRNG() throws {
         let seed: UInt64 = 235_474_323
         var firstResults: [UInt64] = []
-        var subject1 = PRNG(seed: seed)
+        var subject1 = Xoshiro(seed: seed)
         for _ in 0 ... 10 {
             firstResults.append(subject1.next())
         }
 
         var secondResults: [UInt64] = []
-        var subject2 = PRNG(seed: seed)
+        var subject2 = Xoshiro(seed: seed)
         for _ in 0 ... 10 {
             secondResults.append(subject2.next())
         }
@@ -22,13 +21,13 @@ final class PRNGWrapperTests: XCTestCase {
     func testInconsistency_HasherPRNG() throws {
         let seed: UInt64 = 235_474_323
         var firstResults: [UInt64] = []
-        var subject1 = PRNG(seed: seed)
+        var subject1 = Xoshiro(seed: seed)
         for _ in 0 ... 10 {
             firstResults.append(subject1.next())
         }
 
         var secondResults: [UInt64] = []
-        var subject2 = PRNG(seed: seed + 1)
+        var subject2 = Xoshiro(seed: seed + 1)
         for _ in 0 ... 10 {
             secondResults.append(subject2.next())
         }
@@ -38,14 +37,14 @@ final class PRNGWrapperTests: XCTestCase {
     func testPosition_PRNG() throws {
         let seed: UInt64 = 34634
         var firstResults: [UInt64] = []
-        var subject1 = PRNG(seed: seed)
+        var subject1 = Xoshiro(seed: seed)
         let capturedPosition = subject1.position
         for _ in 0 ... 10 {
             firstResults.append(subject1.next())
         }
 
         var secondResults: [UInt64] = []
-        var subject2 = PRNG(seed: seed)
+        var subject2 = Xoshiro(seed: seed)
         subject2.position = capturedPosition
         for _ in 0 ... 10 {
             secondResults.append(subject2.next())
@@ -66,7 +65,7 @@ final class PRNGWrapperTests: XCTestCase {
         XCTAssertEqual(oneEv.prng._invokeCount, 2)
         // print(oneEv.prng.position)
 
-        let sideTest = RNGWrapper(PRNG(seed: 42))
+        let sideTest = RNGWrapper(Xoshiro(seed: 42))
         _ = sideTest.p()
         _ = sideTest.p()
         XCTAssertEqual(sideTest._invokeCount, 2)
@@ -93,7 +92,7 @@ final class PRNGWrapperTests: XCTestCase {
 
         start.prng.resetRNG(seed: start.prng.seed)
         XCTAssertEqual(oneEv.prng.seed, 42)
-        XCTAssertEqual(oneEv.prng.position, 42)
+        XCTAssertEqual(oneEv.prng.position, 0)
         XCTAssertEqual(oneEv.prng._invokeCount, 0)
     }
 }

--- a/Tests/LindenmayerTests/PWrapperTests.swift
+++ b/Tests/LindenmayerTests/PWrapperTests.swift
@@ -6,7 +6,6 @@
 //
 
 @testable import Lindenmayer
-import Squirrel3
 import XCTest
 
 final class PWrapperTests: XCTestCase {
@@ -16,7 +15,7 @@ final class PWrapperTests: XCTestCase {
         }
         let initialP = P(value: 10)
 
-        let f = LSystem.create(Examples2D.Internode(), with: PRNG(seed: 0), using: initialP)
+        let f = LSystem.create(Examples2D.Internode(), with: Xoshiro(seed: 0), using: initialP)
             .rewriteWithParams(directContext: Examples2D.Internode.self) { m, params in
                 XCTAssertEqual(params.value, 10)
                 return [m]
@@ -32,7 +31,7 @@ final class PWrapperTests: XCTestCase {
         }
         let initialP = P(value: 10)
 
-        let f = LSystem.create(Examples2D.Internode(), with: PRNG(seed: 0), using: initialP)
+        let f = LSystem.create(Examples2D.Internode(), with: Xoshiro(seed: 0), using: initialP)
             .rewriteWithParams(directContext: Examples2D.Internode.self) { m, params in
                 XCTAssertEqual(params.value, 13)
                 return [m]

--- a/Tests/LindenmayerTests/RuleTests.swift
+++ b/Tests/LindenmayerTests/RuleTests.swift
@@ -1,5 +1,4 @@
 @testable import Lindenmayer
-import Squirrel3
 import XCTest
 
 final class RuleTests: XCTestCase {
@@ -11,7 +10,7 @@ final class RuleTests: XCTestCase {
 
     func testRuleDefaults() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
-                                     prng: RNGWrapper(PRNG(seed: 0)),
+                                     prng: RNGWrapper(Xoshiro(seed: 0)),
                                      where: nil) { ctx, _ -> [Module] in
             XCTAssertNotNil(ctx)
 
@@ -24,7 +23,7 @@ final class RuleTests: XCTestCase {
 
     func testRuleBasicMatch() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
-                                     prng: RNGWrapper(PRNG(seed: 0)),
+                                     prng: RNGWrapper(Xoshiro(seed: 0)),
                                      where: nil) { _, _ -> [Module] in
             [self.foo]
         }
@@ -35,7 +34,7 @@ final class RuleTests: XCTestCase {
 
     func testRuleBasicFailMatch() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
-                                     prng: RNGWrapper(PRNG(seed: 0)),
+                                     prng: RNGWrapper(Xoshiro(seed: 0)),
                                      where: nil) { _, _ -> [Module] in
             [self.foo]
         }
@@ -45,7 +44,7 @@ final class RuleTests: XCTestCase {
 
     func testRuleMatchExtraRight() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
-                                     prng: RNGWrapper(PRNG(seed: 0)),
+                                     prng: RNGWrapper(Xoshiro(seed: 0)),
                                      where: nil) { _, _ -> [Module] in
             [self.foo]
         }
@@ -57,7 +56,7 @@ final class RuleTests: XCTestCase {
 
     func testRuleMatchExtraLeft() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
-                                     prng: RNGWrapper(PRNG(seed: 0)),
+                                     prng: RNGWrapper(Xoshiro(seed: 0)),
                                      where: nil) { _, _ -> [Module] in
             [self.foo]
         }
@@ -70,7 +69,7 @@ final class RuleTests: XCTestCase {
 
     func testRuleMatchExtraLeftAndRight() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
-                                     prng: RNGWrapper(PRNG(seed: 0)),
+                                     prng: RNGWrapper(Xoshiro(seed: 0)),
                                      where: nil) { _, _ -> [Module] in
             [self.foo]
         }

--- a/Tests/LindenmayerTests/WhiteboxLSystemTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxLSystemTests.swift
@@ -1,10 +1,9 @@
 @testable import Lindenmayer
-import Squirrel3
 import XCTest
 
 final class WhiteboxLSystemTests: XCTestCase {
     func testLSystemDefault() throws {
-        let x = RandomContextualLSystem<PRNG>(axiom: [Examples2D.Internode()], state: nil, newStateIndicators: nil, prng: RNGWrapper(PRNG(seed: 0)))
+        let x = RandomContextualLSystem(axiom: [Examples2D.Internode()], state: nil, newStateIndicators: nil, prng: RNGWrapper(Xoshiro(seed: 0)))
         XCTAssertNotNil(x)
         // Verify internal state of LSystem:
         // No rules

--- a/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
@@ -1,5 +1,4 @@
 @testable import Lindenmayer
-import Squirrel3
 import XCTest
 
 final class WhiteboxParametricRuleTests: XCTestCase {
@@ -20,7 +19,7 @@ final class WhiteboxParametricRuleTests: XCTestCase {
     let p = ParameterizedExample()
 
     func testRuleDefaults() throws {
-        let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self, parameters: ParametersWrapper(ExampleDefines()), prng: RNGWrapper(PRNG(seed: 0)), where: nil) { _, p, _ -> [Module] in
+        let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self, parameters: ParametersWrapper(ExampleDefines()), prng: RNGWrapper(Xoshiro(seed: 0)), where: nil) { _, p, _ -> [Module] in
             [ParameterizedExample(p.value + 1.0)]
         }
 
@@ -45,7 +44,7 @@ final class WhiteboxParametricRuleTests: XCTestCase {
     func testRuleDefaultsWithSystemParameters() throws {
         let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self,
                                             parameters: ParametersWrapper(ExampleDefines()),
-                                            prng: RNGWrapper(PRNG(seed: 0)),
+                                            prng: RNGWrapper(Xoshiro(seed: 0)),
                                             where: nil) { _, p, _ -> [Module] in
             [ParameterizedExample(p.value + p.value)]
         }

--- a/Tests/LindenmayerTests/WhiteboxRuleTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxRuleTests.swift
@@ -1,5 +1,4 @@
 @testable import Lindenmayer
-import Squirrel3
 import XCTest
 
 final class WhiteboxRuleTests: XCTestCase {
@@ -16,7 +15,7 @@ final class WhiteboxRuleTests: XCTestCase {
     }
 
     func testRuleProduction() throws {
-        let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self, prng: RNGWrapper(PRNG(seed: 0)), where: nil) { _, _ in
+        let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self, prng: RNGWrapper(Xoshiro(seed: 0)), where: nil) { _, _ in
             [Examples2D.Internode()]
         }
         XCTAssertNotNil(r)

--- a/docanalyze.bash
+++ b/docanalyze.bash
@@ -22,7 +22,7 @@ xcrun docc convert Sources/Lindenmayer/Lindenmayer.docc \
 --analyze \
 --fallback-display-name Lindenmayer \
 --fallback-bundle-identifier com.github.heckj.Lindenmayer \
---fallback-bundle-version 0.1.0 \
+--fallback-bundle-version 0.7.2 \
 --additional-symbol-graph-dir .build/symbol-graphs \
 --experimental-documentation-coverage \
 --level brief

--- a/docbuild.bash
+++ b/docbuild.bash
@@ -1,36 +1,58 @@
 #!/bin/bash
 
-set -e
-set -x
+echo "Make sure you've rebased over the current HEAD branch:"
+echo "git rebase -i origin/main docs"
 
-rm -rf html
-mkdir -p html
+set -e  # exit on a non-zero return code from a command
+set -x  # print a trace of commands as they execute
 
-rm -rf .build
-mkdir -p .build/symbol-graphs
+#rm -rf .build
+#mkdir -p .build/symbol-graphs
+#
+#$(xcrun --find swift) build --target Lindenmayer --target LindenmayerViews \
+#    -Xswiftc -emit-symbol-graph \
+#    -Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
+#rm -f .build/symbol-graphs/SceneKitDebug* .build/symbol-graphs/Squirrel3*
 
-# Lindenmayer.symbols.json              LindenmayerViews.symbols.json         SceneKitDebugTools@simd.symbols.json
-# Lindenmayer@Swift.symbols.json        SceneKitDebugTools.symbols.json       Squirrel3.symbols.json
-# Lindenmayer@simd.symbols.json         SceneKitDebugTools@Swift.symbols.json
-
-swift build --target Lindenmayer \
---target LindenmayerViews \
--Xswiftc -emit-symbol-graph \
--Xswiftc -emit-symbol-graph-dir -Xswiftc .build/symbol-graphs
-
-# cull the non-Lindenmayer specific builds from the symbol graph files
-rm -f .build/symbol-graphs/SceneKitDebug* .build/symbol-graphs/Squirrel3*
-
+# Enables deterministic output
+# - useful when you're committing the results to host on github pages
 export DOCC_JSON_PRETTYPRINT=YES
 
-xcrun docc convert Sources/Lindenmayer/Lindenmayer.docc \
---enable-inherited-docs \
---output-path Lindenmayer.doccarchive \
---fallback-display-name Lindenmayer \
---fallback-bundle-identifier com.github.heckj.Lindenmayer \
---fallback-bundle-version 0.1.0 \
---additional-symbol-graph-dir .build/symbol-graphs
+#xcrun docc convert Sources/Lindenmayer/Lindenmayer.docc \
+#--enable-inherited-docs \
+#--output-path Lindenmayer.doccarchive \
+#--fallback-display-name Lindenmayer \
+#--fallback-bundle-identifier com.github.heckj.Lindenmayer \
+#--fallback-bundle-version 0.1.0 \
+#--additional-symbol-graph-dir .build/symbol-graphs
 
 #--transform-for-static-hosting \
 #--hosting-base-path '/' \
 #--emit-digest
+
+
+# Swift package plugin for hosted content:
+#
+ $(xcrun --find swift) package \
+     --allow-writing-to-directory ./docs \
+     generate-documentation \
+     --fallback-bundle-identifier com.github.heckj.Lindenmayer \
+     --fallback-bundle-version 0.7.2 \
+     --target Lindenmayer \
+     --target LindenmayerViews \
+     --output-path ./docs \
+     --emit-digest \
+     --disable-indexing \
+     --transform-for-static-hosting \
+     --hosting-base-path 'Lindenmayer'
+
+# Generate a list of all the identifiers to assist in DocC curation
+#
+
+cat docs/linkable-entities.json | jq '.[].referenceURL' -r > all_identifiers.txt
+sort all_identifiers.txt \
+    | sed -e 's/doc:\/\/com\.github\.heckj\.Lindenmayer\/documentation\///g' \
+    | sed -e 's/^/- ``/g' \
+    | sed -e 's/$/``/g' > all_symbols.txt
+
+echo "Page will be available at https://swiftviz.github.io/Lindenmayer/documentation/Lindenmayer/"


### PR DESCRIPTION
- removes CLANG target dependency (C code) in favor of an embedded
  default pseudo-random number generator using the Xoshiro algorithm in
  pure swift. It's not as fast, but effective - and allows for using
  this package within Swift Playgrounds, which doesn't support CLANG
  target dependencies.


resolves #33 