### PR TITLE
Fixing my shadowing of SwiftUI Angle

### DIFF
--- a/Sources/Lindenmayer/Examples/Examples2D.swift
+++ b/Sources/Lindenmayer/Examples/Examples2D.swift
@@ -72,8 +72,8 @@ public enum Examples2D {
     public static var fractalTree = LSystem.create(leaf)
         .rewrite(Leaf.self) { leaf in
             [stem,
-             Modules.Branch(), Modules.TurnLeft(angle: Angle(degrees: 45)), leaf, Modules.EndBranch(),
-             Modules.TurnRight(angle: Angle(degrees: 45)), leaf]
+             Modules.Branch(), Modules.TurnLeft(angle: SimpleAngle(degrees: 45)), leaf, Modules.EndBranch(),
+             Modules.TurnRight(angle: SimpleAngle(degrees: 45)), leaf]
         }
         .rewrite(Stem.self) { stem in
             [stem, stem]
@@ -88,10 +88,10 @@ public enum Examples2D {
     /// The example source for this L-system is [available on GitHub](https://github.com/heckj/Lindenmayer/blob/main/Sources/Lindenmayer/Examples2D.swift).
     public static var kochCurve = LSystem.create(Modules.Draw(length: 10))
         .rewrite(Modules.Draw.self) { _ in
-            [Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees: 90)),
-             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees: 90)),
-             Modules.Draw(length: 10), Modules.TurnRight(angle: Angle(degrees: 90)),
-             Modules.Draw(length: 10), Modules.TurnLeft(angle: Angle(degrees: 90)),
+            [Modules.Draw(length: 10), Modules.TurnLeft(angle: SimpleAngle(degrees: 90)),
+             Modules.Draw(length: 10), Modules.TurnRight(angle: SimpleAngle(degrees: 90)),
+             Modules.Draw(length: 10), Modules.TurnRight(angle: SimpleAngle(degrees: 90)),
+             Modules.Draw(length: 10), Modules.TurnLeft(angle: SimpleAngle(degrees: 90)),
              Modules.Draw(length: 10)]
         }
 
@@ -117,15 +117,15 @@ public enum Examples2D {
     /// The example is a translation of the [Wikipedia example](https://en.wikipedia.org/wiki/L-system#Example_5:_Sierpinski_triangle), rendered at `6` evolutions.
     /// The example source for this L-system is [available on GitHub](https://github.com/heckj/Lindenmayer/blob/main/Sources/Lindenmayer/Examples2D.swift).
     public static var sierpinskiTriangle = LSystem.create(
-        [f, Modules.TurnRight(angle: Angle(degrees: 120)),
-         g, Modules.TurnRight(angle: Angle(degrees: 120)),
-         g, Modules.TurnRight(angle: Angle(degrees: 120))]
+        [f, Modules.TurnRight(angle: SimpleAngle(degrees: 120)),
+         g, Modules.TurnRight(angle: SimpleAngle(degrees: 120)),
+         g, Modules.TurnRight(angle: SimpleAngle(degrees: 120))]
     )
     .rewrite(F.self) { _ in
-        [f, Modules.TurnRight(angle: Angle(degrees: 120)),
-         g, Modules.TurnLeft(angle: Angle(degrees: 120)),
-         f, Modules.TurnLeft(angle: Angle(degrees: 120)),
-         g, Modules.TurnRight(angle: Angle(degrees: 120)),
+        [f, Modules.TurnRight(angle: SimpleAngle(degrees: 120)),
+         g, Modules.TurnLeft(angle: SimpleAngle(degrees: 120)),
+         f, Modules.TurnLeft(angle: SimpleAngle(degrees: 120)),
+         g, Modules.TurnRight(angle: SimpleAngle(degrees: 120)),
          f]
     }
     .rewrite(G.self) { _ in
@@ -141,10 +141,10 @@ public enum Examples2D {
     /// The example source for this L-system is [available on GitHub](https://github.com/heckj/Lindenmayer/blob/main/Sources/Lindenmayer/Examples2D.swift).
     public static var dragonCurve = LSystem.create(f)
         .rewrite(F.self) { _ in
-            [f, Modules.TurnLeft(angle: Angle(degrees: 90)), g]
+            [f, Modules.TurnLeft(angle: SimpleAngle(degrees: 90)), g]
         }
         .rewrite(G.self) { _ in
-            [f, Modules.TurnRight(angle: Angle(degrees: 90)), g]
+            [f, Modules.TurnRight(angle: SimpleAngle(degrees: 90)), g]
         }
 
     // - MARK: Barnsley fern example
@@ -162,14 +162,14 @@ public enum Examples2D {
     /// The example source for this L-system is [available on GitHub](https://github.com/heckj/Lindenmayer/blob/main/Sources/Lindenmayer/Examples2D.swift).
     public static var barnsleyFern = LSystem.create(x)
         .rewrite(X.self) { _ in
-            [f, Modules.TurnLeft(angle: Angle(degrees: 25)),
+            [f, Modules.TurnLeft(angle: SimpleAngle(degrees: 25)),
              Modules.Branch(),
              Modules.Branch(), x, Modules.EndBranch(),
-             Modules.TurnRight(angle: Angle(degrees: 25)), x,
+             Modules.TurnRight(angle: SimpleAngle(degrees: 25)), x,
              Modules.EndBranch(),
-             Modules.TurnRight(angle: Angle(degrees: 25)), f,
-             Modules.Branch(), Modules.TurnRight(angle: Angle(degrees: 25)), f, x, Modules.EndBranch(),
-             Modules.TurnLeft(angle: Angle(degrees: 25)), x]
+             Modules.TurnRight(angle: SimpleAngle(degrees: 25)), f,
+             Modules.Branch(), Modules.TurnRight(angle: SimpleAngle(degrees: 25)), f, x, Modules.EndBranch(),
+             Modules.TurnLeft(angle: SimpleAngle(degrees: 25)), x]
         }
         .rewrite(F.self) { _ in
             [f, f]

--- a/Sources/Lindenmayer/Examples/Examples3D.swift
+++ b/Sources/Lindenmayer/Examples/Examples3D.swift
@@ -236,11 +236,11 @@ public enum Examples3D {
         [
             StaticTrunk(growthDistance: trunk.growthDistance, diameter: trunk.diameter),
             Modules.Branch(),
-            Modules.PitchDown(angle: Angle(degrees: params.branchAngle)),
+            Modules.PitchDown(angle: SimpleAngle(degrees: params.branchAngle)),
             MainBranch(growthDistance: trunk.growthDistance * params.contractionRatioForBranch,
                        diameter: trunk.diameter * params.widthContraction),
             Modules.EndBranch(),
-            Modules.RollLeft(angle: Angle(degrees: params.divergence)),
+            Modules.RollLeft(angle: SimpleAngle(degrees: params.divergence)),
             Trunk(growthDistance: trunk.growthDistance * params.contractionRatioForTrunk,
                   diameter: trunk.diameter * params.widthContraction),
         ]
@@ -252,7 +252,7 @@ public enum Examples3D {
             StaticTrunk(growthDistance: branch.growthDistance, diameter: branch.diameter),
             Modules.Branch(),
 
-            Modules.TurnLeft(angle: Angle(degrees: params.lateralBranchAngle)),
+            Modules.TurnLeft(angle: SimpleAngle(degrees: params.lateralBranchAngle)),
             Modules.RollUpToVertical(),
             SecondaryBranch(growthDistance: branch.growthDistance * params.contractionRatioForBranch,
                             diameter: branch.diameter * params.widthContraction),
@@ -269,7 +269,7 @@ public enum Examples3D {
             StaticTrunk(growthDistance: branch.growthDistance, diameter: branch.diameter),
             Modules.Branch(),
 
-            Modules.TurnRight(angle: Angle(degrees: params.branchAngle)),
+            Modules.TurnRight(angle: SimpleAngle(degrees: params.branchAngle)),
             Modules.RollUpToVertical(),
 
             MainBranch(growthDistance: branch.growthDistance * params.contractionRatioForBranch,
@@ -359,14 +359,14 @@ public enum Examples3D {
             StaticTrunk(growthDistance: node.growthDistance, diameter: node.diameter),
 
             Modules.Branch(),
-            Modules.PitchDown(angle: Angle(degrees: params.a1)),
+            Modules.PitchDown(angle: SimpleAngle(degrees: params.a1)),
             SecondaryBranch(growthDistance: node.growthDistance * params.r1, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
 
-            Modules.RollLeft(angle: Angle(degrees: 180)),
+            Modules.RollLeft(angle: SimpleAngle(degrees: 180)),
 
             Modules.Branch(),
-            Modules.PitchDown(angle: Angle(degrees: params.a2)),
+            Modules.PitchDown(angle: SimpleAngle(degrees: params.a2)),
             SecondaryBranch(growthDistance: node.growthDistance * params.r2, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
         ]
@@ -376,12 +376,12 @@ public enum Examples3D {
         [
             StaticTrunk(growthDistance: node.growthDistance, diameter: node.diameter),
             Modules.Branch(),
-            Modules.TurnRight(angle: Angle(degrees: params.a1)),
+            Modules.TurnRight(angle: SimpleAngle(degrees: params.a1)),
             Modules.RollUpToVertical(),
             SecondaryBranch(growthDistance: node.growthDistance * params.r1, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
             Modules.Branch(),
-            Modules.TurnLeft(angle: Angle(degrees: params.a2)),
+            Modules.TurnLeft(angle: SimpleAngle(degrees: params.a2)),
             Modules.RollUpToVertical(),
             SecondaryBranch(growthDistance: node.growthDistance * params.r2, diameter: node.diameter * params.wr),
             Modules.EndBranch(),
@@ -423,13 +423,13 @@ public enum Examples3D {
             if rng.p(0.5) {
                 return [
                     StaticStem2(length: 2),
-                    Modules.PitchDown(angle: Angle(degrees: Double(rng.randomFloat(in: lower ... upper)))),
+                    Modules.PitchDown(angle: SimpleAngle(degrees: Double(rng.randomFloat(in: lower ... upper)))),
                     Stem2(length: stem.length),
                 ]
             } else {
                 return [
                     StaticStem2(length: 2),
-                    Modules.PitchUp(angle: Angle(degrees: Double(rng.randomFloat(in: lower ... upper)))),
+                    Modules.PitchUp(angle: SimpleAngle(degrees: Double(rng.randomFloat(in: lower ... upper)))),
                     Stem2(length: stem.length),
                 ]
             }

--- a/Sources/Lindenmayer/Modules/BuiltinModules.swift
+++ b/Sources/Lindenmayer/Modules/BuiltinModules.swift
@@ -29,12 +29,13 @@ import Foundation
 public enum Modules {}
 
 public extension Modules {
+
     // MARK: - Built-in Modules that are effectively wrappers around specific rendering commands
 
     /// A module that informs a renderer to turn left while rendering the L-system.
     struct TurnLeft: Module {
         public let name = RenderCommand.turnLeft.name
-        public let angle: Angle
+        public let angle: SimpleAngle
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.TurnLeft(angle: angle)]
         }
@@ -43,7 +44,7 @@ public extension Modules {
             RenderCommand.TurnLeft(angle: angle)
         }
 
-        public init(angle: Angle = Angle.degrees(90)) {
+        public init(angle: SimpleAngle = .degrees(90)) {
             self.angle = angle
         }
     }
@@ -51,7 +52,7 @@ public extension Modules {
     /// A module that informs a renderer to turn right while rendering the L-system.
     struct TurnRight: Module {
         public let name = RenderCommand.turnRight.name
-        public let angle: Angle
+        public let angle: SimpleAngle
         public var render2D: [TwoDRenderCmd] {
             [RenderCommand.TurnRight(angle: angle)]
         }
@@ -60,7 +61,7 @@ public extension Modules {
             RenderCommand.TurnRight(angle: angle)
         }
 
-        public init(angle: Angle = .degrees(90)) {
+        public init(angle: SimpleAngle = .degrees(90)) {
             self.angle = angle
         }
     }
@@ -131,7 +132,7 @@ public extension Modules {
     /// A module that informs a renderer to change the heading by rolling around the current axis to the left.
     struct RollLeft: Module {
         public let name = RenderCommand.rollLeft.name
-        public let angle: Angle
+        public let angle: SimpleAngle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -140,7 +141,7 @@ public extension Modules {
             RenderCommand.RollLeft(angle: angle)
         }
 
-        public init(angle: Angle = .degrees(90)) {
+        public init(angle: SimpleAngle = .degrees(90)) {
             self.angle = angle
         }
     }
@@ -148,7 +149,7 @@ public extension Modules {
     /// A module that informs a renderer to change the heading by rolling around the current axis to the right.
     struct RollRight: Module {
         public let name = RenderCommand.rollRight.name
-        public let angle: Angle
+        public let angle: SimpleAngle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -157,7 +158,7 @@ public extension Modules {
             RenderCommand.RollRight(angle: angle)
         }
 
-        public init(angle: Angle = .degrees(90)) {
+        public init(angle: SimpleAngle = .degrees(90)) {
             self.angle = angle
         }
     }
@@ -165,7 +166,7 @@ public extension Modules {
     /// A module that informs a renderer to change the heading by pitching up.
     struct PitchUp: Module {
         public let name = RenderCommand.pitchUp.name
-        public let angle: Angle
+        public let angle: SimpleAngle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -174,7 +175,7 @@ public extension Modules {
             RenderCommand.PitchUp(angle: angle)
         }
 
-        public init(angle: Angle = .degrees(30)) {
+        public init(angle: SimpleAngle = .degrees(30)) {
             self.angle = angle
         }
     }
@@ -182,7 +183,7 @@ public extension Modules {
     /// A module that informs a renderer to change the heading by pitching down.
     struct PitchDown: Module {
         public let name = RenderCommand.pitchDown.name
-        public let angle: Angle
+        public let angle: SimpleAngle
         public var render2D: [TwoDRenderCmd] {
             []
         }
@@ -191,7 +192,7 @@ public extension Modules {
             RenderCommand.PitchDown(angle: angle)
         }
 
-        public init(angle: Angle = .degrees(30)) {
+        public init(angle: SimpleAngle = .degrees(30)) {
             self.angle = angle
         }
     }

--- a/Sources/Lindenmayer/Rendering/Angle.swift
+++ b/Sources/Lindenmayer/Rendering/Angle.swift
@@ -6,14 +6,6 @@
 //
 
 import Foundation
-#if canImport(SwiftUI)
-    import SwiftUI
-    /// A geometric angle whose value you access in either radians or degrees.
-    public typealias Angle = SwiftUI.Angle
-#else
-    /// A geometric angle whose value you access in either radians or degrees.
-    public typealias Angle = SimpleAngle
-#endif
 
 /// A geometric angle whose value you access in either radians or degrees.
 ///
@@ -35,34 +27,42 @@ import Foundation
 @frozen public struct SimpleAngle {
     /// The value of the angle in radians.
     public var radians: Double
-
+    
     /// The value of the angle in degrees.
     @inlinable public var degrees: Double {
         return radians * 180.0 / .pi
     }
-
+    
     /// Creates a new Angle of zero radians.
     @inlinable public init() {
         radians = 0
     }
-
+    
     /// Creates a new Angle with the value of radians you provide.
     @inlinable public init(radians: Double) {
         self.radians = radians
     }
-
+    
     /// Creates a new Angle with the value of degrees you provide.
     @inlinable public init(degrees: Double) {
         radians = degrees * .pi / 180
     }
-
+    
     /// Creates a new Angle with the value of radians you provide.
-    @inlinable public static func radians(_ radians: Double) -> Angle {
-        return Angle(radians: radians)
+    @inlinable public static func radians(_ radians: Double) -> SimpleAngle {
+        return SimpleAngle(radians: radians)
     }
-
+    
     /// Creates a new Angle with the value of degrees you provide.
-    @inlinable public static func degrees(_ degrees: Double) -> Angle {
-        return Angle(degrees: degrees)
+    @inlinable public static func degrees(_ degrees: Double) -> SimpleAngle {
+        return SimpleAngle(degrees: degrees)
+    }
+    
+    @inlinable public static func + (left: SimpleAngle, right: SimpleAngle) -> SimpleAngle {
+        return SimpleAngle(radians: left.radians+right.radians)
+    }
+    
+    @inlinable public static func - (left: SimpleAngle, right: SimpleAngle) -> SimpleAngle {
+        return SimpleAngle(radians: left.radians-right.radians)
     }
 }

--- a/Sources/Lindenmayer/Rendering/GraphicsContextRenderer.swift
+++ b/Sources/Lindenmayer/Rendering/GraphicsContextRenderer.swift
@@ -9,16 +9,16 @@ import CoreGraphics
 import SwiftUI
 
 struct PathState {
-    var angle: Angle
+    var angle: SimpleAngle
     var position: CGPoint
     var lineWidth: Double
     var lineColor: ColorRepresentation
 
     init() {
-        self.init(Angle(degrees: -90), .zero, 1.0, ColorRepresentation.black)
+        self.init(SimpleAngle(degrees: -90), .zero, 1.0, ColorRepresentation.black)
     }
 
-    init(_ angle: Angle, _ position: CGPoint, _ lineWidth: Double, _ lineColor: ColorRepresentation) {
+    init(_ angle: SimpleAngle, _ position: CGPoint, _ lineWidth: Double, _ lineColor: ColorRepresentation) {
         self.angle = angle
         self.position = position
         self.lineWidth = lineWidth
@@ -270,7 +270,7 @@ public struct GraphicsContextRenderer {
         return PathState(state.angle, state.position, state.lineWidth, lineColor)
     }
 
-    func updatedStateByTurning(_ state: PathState, angle: Angle, direction: TurnDirection)
+    func updatedStateByTurning(_ state: PathState, angle: SimpleAngle, direction: TurnDirection)
         -> PathState
     {
         if direction == .left {

--- a/Sources/Lindenmayer/Rendering/RenderCommands.swift
+++ b/Sources/Lindenmayer/Rendering/RenderCommands.swift
@@ -319,8 +319,8 @@ public enum RenderCommand {
     public struct TurnLeft: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.leftTurn.rawValue
 
-        public let angle: Angle
-        public init(angle: Angle) {
+        public let angle: SimpleAngle
+        public init(angle: SimpleAngle) {
             self.angle = angle
         }
     }
@@ -340,8 +340,8 @@ public enum RenderCommand {
     public struct TurnRight: TwoDRenderCmd, ThreeDRenderCmd {
         public let name: String = TurtleCodes.rightTurn.rawValue
 
-        public let angle: Angle
-        public init(angle: Angle) {
+        public let angle: SimpleAngle
+        public init(angle: SimpleAngle) {
             self.angle = angle
         }
     }
@@ -417,8 +417,8 @@ public enum RenderCommand {
     /// - ``RenderCommand/PitchUp-swift.struct/angle``
     public struct PitchUp: ThreeDRenderCmd {
         public let name = TurtleCodes.pitchUp.rawValue
-        public let angle: Angle
-        public init(angle: Angle) {
+        public let angle: SimpleAngle
+        public init(angle: SimpleAngle) {
             self.angle = angle
         }
     }
@@ -437,8 +437,8 @@ public enum RenderCommand {
     /// - ``RenderCommand/PitchDown-swift.struct/angle``
     public struct PitchDown: ThreeDRenderCmd {
         public let name = TurtleCodes.pitchDown.rawValue
-        public let angle: Angle
-        public init(angle: Angle) {
+        public let angle: SimpleAngle
+        public init(angle: SimpleAngle) {
             self.angle = angle
         }
     }
@@ -457,8 +457,8 @@ public enum RenderCommand {
     /// - ``RenderCommand/RollRight-swift.struct/angle``
     public struct RollRight: ThreeDRenderCmd {
         public let name = TurtleCodes.rollRight.rawValue
-        public let angle: Angle
-        public init(angle: Angle) {
+        public let angle: SimpleAngle
+        public init(angle: SimpleAngle) {
             self.angle = angle
         }
     }
@@ -477,8 +477,8 @@ public enum RenderCommand {
     /// - ``RenderCommand/RollLeft-swift.struct/angle``
     public struct RollLeft: ThreeDRenderCmd {
         public let name = TurtleCodes.rollLeft.rawValue
-        public let angle: Angle
-        public init(angle: Angle) {
+        public let angle: SimpleAngle
+        public init(angle: SimpleAngle) {
             self.angle = angle
         }
     }

--- a/Sources/Lindenmayer/Rendering/SceneKitRenderer.swift
+++ b/Sources/Lindenmayer/Rendering/SceneKitRenderer.swift
@@ -121,7 +121,7 @@ public struct SceneKitRenderer {
         // vector on the rotated plane, and from that the two-argument arctangent gets us
         // the angle of the vector from the positive X-axis in that plane.
         let resulting_angle = atan2(simd_dot(rotated_up_vector, planeRight), simd_dot(rotated_up_vector, planeUp))
-        print("And the resulting angle: \(resulting_angle) (\(Angle(radians: Double(resulting_angle)).degrees)°)")
+        print("And the resulting angle: \(resulting_angle) (\(SimpleAngle(radians: Double(resulting_angle)).degrees)°)")
         return resulting_angle
     }
 
@@ -167,7 +167,7 @@ public struct SceneKitRenderer {
             case TurtleCodes.pitchDown.rawValue:
                 // negative values pitch nose down (negative rotation around X axis)
                 if let cmd = cmd as? RenderCommand.PitchDown {
-                    let directionAngle = Angle(radians: -1.0 * cmd.angle.radians)
+                    let directionAngle = SimpleAngle(radians: -1.0 * cmd.angle.radians)
                     let pitchTransform = SceneKitRenderer.rotationAroundXAxisTransform(angle: directionAngle)
                     currentState = currentState.applyingTransform(pitchTransform)
 //                    print("Pitch (rotate around -X Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
@@ -176,7 +176,7 @@ public struct SceneKitRenderer {
             case TurtleCodes.rollLeft.rawValue:
                 if let cmd = cmd as? RenderCommand.RollLeft {
                     // negative values roll to the left (negative rotation around Y axis)
-                    let directionAngle = Angle(radians: -1.0 * cmd.angle.radians)
+                    let directionAngle = SimpleAngle(radians: -1.0 * cmd.angle.radians)
                     let rollTransform = SceneKitRenderer.rotationAroundYAxisTransform(angle: directionAngle)
                     currentState = currentState.applyingTransform(rollTransform)
 //                    print("Roll (rotate around -Y Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
@@ -201,14 +201,14 @@ public struct SceneKitRenderer {
             case TurtleCodes.rightTurn.rawValue:
                 if let cmd = cmd as? RenderCommand.TurnRight {
                     // negative values turn to the right (negative rotation around Z axis)
-                    let directionAngle = Angle(radians: -1.0 * cmd.angle.radians)
+                    let directionAngle = SimpleAngle(radians: -1.0 * cmd.angle.radians)
                     let yawTransform = SceneKitRenderer.rotationAroundZAxisTransform(angle: directionAngle)
                     currentState = currentState.applyingTransform(yawTransform)
 //                    print("Yaw (rotate around -Z Axis) by \(cmd.angle)° -> \(String(describing: currentState.transform))")
                 }
 
             case TurtleCodes.rollUpToVertical.rawValue:
-                let resulting_angle = Angle(radians: -1.0 * Double(rotateAroundHeadingToVertical(currentState.transform)))
+                let resulting_angle = SimpleAngle(radians: -1.0 * Double(rotateAroundHeadingToVertical(currentState.transform)))
                 let rotationTransform = SceneKitRenderer.rotationAroundYAxisTransform(angle: resulting_angle)
                 currentState = currentState.applyingTransform(rotationTransform)
 

--- a/Sources/Lindenmayer/Rendering/Transforms.swift
+++ b/Sources/Lindenmayer/Rendering/Transforms.swift
@@ -41,7 +41,7 @@ public extension SceneKitRenderer {
     /// Creates a 3D rotation transform that rotates around the Z axis by the angle that you provide
     /// - Parameter angle: The amount (in radians) to rotate around the Z axis.
     /// - Returns: A Z-axis rotation transform.
-    static func rotationAroundZAxisTransform(angle: Angle) -> simd_float4x4 {
+    static func rotationAroundZAxisTransform(angle: SimpleAngle) -> simd_float4x4 {
         return simd_float4x4(
             SIMD4<Float>(cos(Float(angle.radians)), sin(Float(angle.radians)), 0, 0),
             SIMD4<Float>(-sin(Float(angle.radians)), cos(Float(angle.radians)), 0, 0),
@@ -53,7 +53,7 @@ public extension SceneKitRenderer {
     /// Creates a 3D rotation transform that rotates around the X axis by the angle that you provide
     /// - Parameter angle: The amount (in radians) to rotate around the X axis.
     /// - Returns: A X-axis rotation transform.
-    static func rotationAroundXAxisTransform(angle: Angle) -> simd_float4x4 {
+    static func rotationAroundXAxisTransform(angle: SimpleAngle) -> simd_float4x4 {
         return simd_float4x4(
             SIMD4<Float>(1, 0, 0, 0),
             SIMD4<Float>(0, cos(Float(angle.radians)), sin(Float(angle.radians)), 0),
@@ -65,7 +65,7 @@ public extension SceneKitRenderer {
     /// Creates a 3D rotation transform that rotates around the Y axis by the angle that you provide
     /// - Parameter angle: The amount (in radians) to rotate around the Y axis.
     /// - Returns: A Y-axis rotation transform.
-    static func rotationAroundYAxisTransform(angle: Angle) -> simd_float4x4 {
+    static func rotationAroundYAxisTransform(angle: SimpleAngle) -> simd_float4x4 {
         return simd_float4x4(
             SIMD4<Float>(cos(Float(angle.radians)), 0, -sin(Float(angle.radians)), 0),
             SIMD4<Float>(0, 1, 0, 0),

--- a/Sources/LindenmayerViews/Debug/RollToVerticalTestView.swift
+++ b/Sources/LindenmayerViews/Debug/RollToVerticalTestView.swift
@@ -92,14 +92,14 @@ public struct RollToVerticalTestView: View {
     public var body: some View {
         VStack {
             HStack {
-                Text("Angle: \(calculated_angle) ( \(Angle(radians: Double(calculated_angle)).degrees)° )")
+                Text("Angle: \(calculated_angle) ( \(SimpleAngle(radians: Double(calculated_angle)).degrees)° )")
                 TextField("roll amount", text: $aString)
                 Button {
                     if let selectedNode = selectedNode {
                         if let angle = Double(aString) {
                             print("before rotation")
                             print("\(pointSphereZ.simdTransform.prettyPrintString())")
-                            let rotationTransform = SceneKitRenderer.rotationAroundYAxisTransform(angle: Angle(radians: angle))
+                            let rotationTransform = SceneKitRenderer.rotationAroundYAxisTransform(angle: SimpleAngle(radians: angle))
                             selectedNode.simdTransform = matrix_multiply(selectedNode.simdTransform, rotationTransform)
                             pointSphere0.simdTransform = matrix_multiply(pointSphere0.simdTransform, rotationTransform)
 
@@ -138,7 +138,7 @@ public struct RollToVerticalTestView: View {
         zLine.simdPosition = simd_float3(0, 0, 0.5)
 //        let zLineNudge = translationTransform(x: 0, y: 0, z: 0.5)
 //        zLine.simdTransform = matrix_multiply(zLine.simdTransform, zLineNudge)
-        let zLineRotation = SceneKitRenderer.rotationAroundXAxisTransform(angle: Angle(degrees: 90))
+        let zLineRotation = SceneKitRenderer.rotationAroundXAxisTransform(angle: SimpleAngle(degrees: 90))
         zLine.simdTransform = matrix_multiply(zLine.simdTransform, zLineRotation)
 //        zLine.simdTransform = matrix_multiply(zLine.simdTransform, RollToVerticalTestView.transform_119)
         scene.rootNode.addChildNode(zLine)

--- a/Tests/LindenmayerTests/RollUpToVerticalTests.swift
+++ b/Tests/LindenmayerTests/RollUpToVerticalTests.swift
@@ -57,7 +57,7 @@ final class RollUpToVerticalTests: XCTestCase {
 
     func testApplyingKnownTransformsToA3DPoint() throws {
         let pt = simd_float3(0, 0, 1) // x=0, y=0, z=1
-        let rotate_90_around_Y = SceneKitRenderer.rotationAroundYAxisTransform(angle: Angle(degrees: 90)).rotationTransform
+        let rotate_90_around_Y = SceneKitRenderer.rotationAroundYAxisTransform(angle: SimpleAngle(degrees: 90)).rotationTransform
 
         // DUH tests - identity should be equivalent in either direction
         XCTAssertEqual(matrix_multiply(matrix_identity_float3x3, pt), pt)
@@ -89,7 +89,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testHeadingVectorRotating45degToRight() throws {
         // This rotation is a "right turn" from the starting position, straight up. We rotation 45° around
         // the Z axis - negative rotation to make it to the right.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: Angle(degrees: -45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: SimpleAngle(degrees: -45)))
         print(state_transform.prettyPrintString())
 //        [0.7071068, 0.70710677, 0.0, 0.0]
 //        [-0.70710677, 0.7071068, 0.0, 0.0]
@@ -105,7 +105,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testHeadingVectorRotating45degToLeft() throws {
         // This rotation is a "right turn" from the starting position, straight up.
         // We rotate 45° around the Z axis - negative rotation to make it to the right.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: Angle(degrees: 45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: SimpleAngle(degrees: 45)))
 //        print(state_transform.prettyPrintString())
 //        [0.7071068, -0.70710677, 0.0, 0.0]
 //        [0.70710677, 0.7071068, 0.0, 0.0]
@@ -120,7 +120,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testHeadingVectorRotating45degPitchDown() throws {
         // This rotation is a "pitch up" from the starting position, straight up.
         // We rotate 45° around the X axis - negative rotation to make it pitch 'down'.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: Angle(degrees: -45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: SimpleAngle(degrees: -45)))
         print(state_transform.prettyPrintString())
         let heading_vector = state_transform.headingVector()
         XCTAssertEqual(heading_vector.x, 0, accuracy: 0.0001)
@@ -131,7 +131,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testHeadingVectorRotating45degPitchUp() throws {
         // This rotation is a "pitch down" from the starting position, straight up.
         // We rotate 45° around the X axis - positive rotation to make it to pitch 'up'.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: Angle(degrees: 45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: SimpleAngle(degrees: 45)))
         let heading_vector = state_transform.headingVector()
         XCTAssertEqual(heading_vector.x, 0, accuracy: 0.0001)
         XCTAssertEqual(heading_vector.y, 0.7071067, accuracy: 0.0001)
@@ -141,7 +141,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testHeadingVectorRotating45degYaw() throws {
         // This rotation is a "pitch down" from the starting position, straight up.
         // We rotate 45° around the X axis - positive rotation to make it to pitch 'up'.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundYAxisTransform(angle: Angle(degrees: 45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundYAxisTransform(angle: SimpleAngle(degrees: 45)))
         let heading_vector = state_transform.headingVector()
         XCTAssertEqual(heading_vector.x, 0, accuracy: 0.0001)
         XCTAssertEqual(heading_vector.y, 1, accuracy: 0.0001)
@@ -151,7 +151,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testUpVectorAfterRotation() throws {
         let original_up_vector = simd_float3(x: 0, y: 0, z: 1)
         // roll to the right
-        let rotationAffineTransform = SceneKitRenderer.rotationAroundYAxisTransform(angle: Angle(degrees: 45))
+        let rotationAffineTransform = SceneKitRenderer.rotationAroundYAxisTransform(angle: SimpleAngle(degrees: 45))
         let rotated_up = matrix_multiply(rotationAffineTransform.rotationTransform, original_up_vector)
         XCTAssertEqual(rotated_up.x, 0.7071067, accuracy: 0.0001)
         XCTAssertEqual(rotated_up.y, 0, accuracy: 0.0001)
@@ -174,7 +174,7 @@ final class RollUpToVerticalTests: XCTestCase {
         // the Z axis - negative rotation to make it to the right.
         // The resulting rotation plane is tilted 45° to the right as well, so should result in a rotation
         // of -90° on that plane to get the "up" vector as close to +Y as possible.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: Angle(degrees: -45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: SimpleAngle(degrees: -45)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         XCTAssertEqual(Float.pi / 2, rotation_on_plane, accuracy: 0.0001)
@@ -185,7 +185,7 @@ final class RollUpToVerticalTests: XCTestCase {
         // the Z axis - negative rotation to make it to the right.
         // The resulting rotation plane is tilted 45° to the right as well, so should result in a rotation
         // of -90° on that plane to get the "up" vector as close to +Y as possible.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: Angle(degrees: 45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: SimpleAngle(degrees: 45)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         XCTAssertEqual(-Float.pi / 2, rotation_on_plane, accuracy: 0.0001)
@@ -196,7 +196,7 @@ final class RollUpToVerticalTests: XCTestCase {
         // the X axis - negative rotation to make it pitch 'up'.
         // The resulting rotation plane is tilted 45° up towards -Z, so should result in a rotation
         // of 180° on that plane to get the "up" vector as close to +Y as possible.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: Angle(degrees: 45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: SimpleAngle(degrees: 45)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         XCTAssertEqual(Float.pi, rotation_on_plane, accuracy: 0.0001)
@@ -207,7 +207,7 @@ final class RollUpToVerticalTests: XCTestCase {
         // the X axis - positive rotation to make it to pitch 'down'.
         // The resulting rotation plane is tilted 45° up towards the +z, so should result in a rotation
         // of 0° on that plane to get the "up" vector as close to +Y as possible.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: Angle(degrees: -45)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: SimpleAngle(degrees: -45)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         XCTAssertEqual(0, rotation_on_plane, accuracy: 0.0001)
@@ -216,7 +216,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testRotating90degPitchUpMatrix() throws {
         // Since we start facing straight up, pitching up another 90° results in us facing the +z direction
         // with the "up" vector now rotated to point pretty much straight in the -Y direction.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: Angle(degrees: 90)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: SimpleAngle(degrees: 90)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         // this one could be -.pi or pi, depending on rounding issues - so check absolute value for this one
@@ -226,7 +226,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testRotating90degPitchDownMatrix() throws {
         // Since we start facing straight up, pitching up another 90° results in us facing the +z direction
         // with the "up" vector now rotated to point pretty much straight in the -Y direction.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: Angle(degrees: -90)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundXAxisTransform(angle: SimpleAngle(degrees: -90)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         XCTAssertEqual(0, rotation_on_plane, accuracy: 0.0001)
@@ -235,7 +235,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testRotating90degToRight() throws {
         // Since we start facing straight up, pitching up another 90° results in us facing the +z direction
         // with the "up" vector now rotated to point pretty much straight in the -Y direction.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: Angle(degrees: -90)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: SimpleAngle(degrees: -90)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         XCTAssertEqual(Float.pi / 2, rotation_on_plane, accuracy: 0.0001)
@@ -244,7 +244,7 @@ final class RollUpToVerticalTests: XCTestCase {
     func testRotating90degToLeft() throws {
         // Since we start facing straight up, pitching up another 90° results in us facing the +z direction
         // with the "up" vector now rotated to point pretty much straight in the -Y direction.
-        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: Angle(degrees: 90)))
+        let state_transform = matrix_multiply(matrix_identity_float4x4, SceneKitRenderer.rotationAroundZAxisTransform(angle: SimpleAngle(degrees: 90)))
         let r = RollUpToVerticalTests.renderer
         let rotation_on_plane = r.rotateAroundHeadingToVertical(state_transform)
         XCTAssertEqual(-Float.pi / 2, rotation_on_plane, accuracy: 0.0001)

--- a/Tests/LindenmayerTests/TransformTests.swift
+++ b/Tests/LindenmayerTests/TransformTests.swift
@@ -38,7 +38,7 @@ final class TransformTests: XCTestCase {
 
     func testRollTransformMatchesSceneKit() throws {
         let node = SCNNode()
-        let angle = Angle(degrees: 30)
+        let angle = SimpleAngle(degrees: 30)
         // pitch, yaw, roll
         node.simdEulerAngles = simd_float3(x: 0, y: 0, z: Float(angle.radians))
 
@@ -49,7 +49,7 @@ final class TransformTests: XCTestCase {
 
     func testYawTransformMatchesSceneKit() throws {
         let node = SCNNode()
-        let angle = Angle(degrees: 30)
+        let angle = SimpleAngle(degrees: 30)
         // pitch, yaw, roll
         node.simdEulerAngles = simd_float3(x: 0, y: Float(angle.radians), z: 0)
 
@@ -60,7 +60,7 @@ final class TransformTests: XCTestCase {
 
     func testPitchTransformMatchesSceneKit() throws {
         let node = SCNNode()
-        let angle = Angle(degrees: 30)
+        let angle = SimpleAngle(degrees: 30)
         // pitch, yaw, roll
         node.simdEulerAngles = simd_float3(x: Float(angle.radians), y: 0, z: 0)
 


### PR DESCRIPTION
 - my workaround for typealiasing when it wasn't available looks like it'll be a failure with Swift6 due to implicit typing issues in some of the sources.