### PR TITLE
use @_exported to expand SwiftUI Angle to be easier to find

### DIFF
--- a/Sources/Lindenmayer/Modules/BuiltinModules.swift
+++ b/Sources/Lindenmayer/Modules/BuiltinModules.swift
@@ -60,7 +60,7 @@ public extension Modules {
             RenderCommand.TurnRight(angle: angle)
         }
 
-        public init(angle: Angle = .degrees(90)) {
+        public init(angle: Angle = Angle.degrees(90)) {
             self.angle = angle
         }
     }

--- a/Sources/Lindenmayer/PRNG/RNGWrapper.swift
+++ b/Sources/Lindenmayer/PRNG/RNGWrapper.swift
@@ -95,7 +95,7 @@ public final class RNGWrapper<PRNG> where PRNG: SeededRandomNumberGenerator {
         // ensure that the provided probability is between 0.0 and 1.0
         precondition(prob > 0.0 && prob < 1.0)
         let selectedProb = randomFloat(in: 0.0 ... 1.0)
-        return (selectedProb <= prob)
+        return selectedProb <= prob
     }
 
     /// Returns a random float value between 0.0 and 1.0.

--- a/Sources/Lindenmayer/Rendering/Angle.swift
+++ b/Sources/Lindenmayer/Rendering/Angle.swift
@@ -8,7 +8,6 @@
 import Foundation
 #if canImport(SwiftUI)
     @_exported import SwiftUI
-//    import SwiftUI
     /// A geometric angle whose value you access in either radians or degrees.
     public typealias Angle = SwiftUI.Angle
 #else

--- a/Sources/Lindenmayer/Rendering/Angle.swift
+++ b/Sources/Lindenmayer/Rendering/Angle.swift
@@ -1,5 +1,5 @@
 //
-//  Angel.swift
+//  Angle.swift
 //
 //
 //  Created by Joseph Heck on 1/22/22.
@@ -7,7 +7,8 @@
 
 import Foundation
 #if canImport(SwiftUI)
-    import SwiftUI
+    @_exported import SwiftUI
+//    import SwiftUI
     /// A geometric angle whose value you access in either radians or degrees.
     public typealias Angle = SwiftUI.Angle
 #else

--- a/Sources/LindenmayerViews/Lsystem3DView.swift
+++ b/Sources/LindenmayerViews/Lsystem3DView.swift
@@ -1,5 +1,5 @@
 //
-//  LSystem3DView.swift
+//  Lsystem3DView.swift
 //
 //
 //  Created by Joseph Heck on 12/18/21.

--- a/Tests/LindenmayerTests/RuleTests.swift
+++ b/Tests/LindenmayerTests/RuleTests.swift
@@ -11,7 +11,8 @@ final class RuleTests: XCTestCase {
     func testRuleDefaults() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
                                      prng: RNGWrapper(Xoshiro(seed: 0)),
-                                     where: nil) { ctx, _ -> [Module] in
+                                     where: nil)
+        { ctx, _ -> [Module] in
             XCTAssertNotNil(ctx)
 
             return [ctx]
@@ -24,7 +25,8 @@ final class RuleTests: XCTestCase {
     func testRuleBasicMatch() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
                                      prng: RNGWrapper(Xoshiro(seed: 0)),
-                                     where: nil) { _, _ -> [Module] in
+                                     where: nil)
+        { _, _ -> [Module] in
             [self.foo]
         }
 
@@ -35,7 +37,8 @@ final class RuleTests: XCTestCase {
     func testRuleBasicFailMatch() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
                                      prng: RNGWrapper(Xoshiro(seed: 0)),
-                                     where: nil) { _, _ -> [Module] in
+                                     where: nil)
+        { _, _ -> [Module] in
             [self.foo]
         }
         let moduleSet = ModuleSet(directInstance: foo)
@@ -45,7 +48,8 @@ final class RuleTests: XCTestCase {
     func testRuleMatchExtraRight() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
                                      prng: RNGWrapper(Xoshiro(seed: 0)),
-                                     where: nil) { _, _ -> [Module] in
+                                     where: nil)
+        { _, _ -> [Module] in
             [self.foo]
         }
         let moduleSet = ModuleSet(leftInstance: nil,
@@ -57,7 +61,8 @@ final class RuleTests: XCTestCase {
     func testRuleMatchExtraLeft() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
                                      prng: RNGWrapper(Xoshiro(seed: 0)),
-                                     where: nil) { _, _ -> [Module] in
+                                     where: nil)
+        { _, _ -> [Module] in
             [self.foo]
         }
         let moduleSet = ModuleSet(leftInstance: Foo(),
@@ -70,7 +75,8 @@ final class RuleTests: XCTestCase {
     func testRuleMatchExtraLeftAndRight() throws {
         let r = RewriteRuleDirectRNG(directType: Examples2D.Internode.self,
                                      prng: RNGWrapper(Xoshiro(seed: 0)),
-                                     where: nil) { _, _ -> [Module] in
+                                     where: nil)
+        { _, _ -> [Module] in
             [self.foo]
         }
         let moduleSet = ModuleSet(leftInstance: Foo(),

--- a/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxParametricRuleTests.swift
@@ -45,7 +45,8 @@ final class WhiteboxParametricRuleTests: XCTestCase {
         let r = RewriteRuleDirectDefinesRNG(directType: ParameterizedExample.self,
                                             parameters: ParametersWrapper(ExampleDefines()),
                                             prng: RNGWrapper(Xoshiro(seed: 0)),
-                                            where: nil) { _, p, _ -> [Module] in
+                                            where: nil)
+        { _, p, _ -> [Module] in
             [ParameterizedExample(p.value + p.value)]
         }
 

--- a/Tests/LindenmayerTests/WhiteboxRuleTests.swift
+++ b/Tests/LindenmayerTests/WhiteboxRuleTests.swift
@@ -4,7 +4,8 @@ import XCTest
 final class WhiteboxRuleTests: XCTestCase {
     func testRuleDefaults() throws {
         let r = RewriteRuleDirect(direct: Examples2D.Internode.self,
-                                  where: nil) { ctx in
+                                  where: nil)
+        { ctx in
             [ctx]
         }
         XCTAssertNotNil(r)


### PR DESCRIPTION
resolving Swift6 implicit use warnings in Xcode 15.1